### PR TITLE
Remove problematic whitespace from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,9 +15,9 @@
 
 
 Parts of the Image library were ported from the following sources:
-   
-==============================================================================   
- 
+
+==============================================================================
+
  The JPEG encoder/decoder code is derived from the following:
    https://github.com/notmasteryet/jpgjs
    Copyright (C) 2011 notmasteryet
@@ -70,8 +70,8 @@ The WebP encoder/decoder code is derived from the following:
   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-==============================================================================  
+  
+==============================================================================
 
 The TIFF decoder code is derived from the following:
   Apache Batik
@@ -90,7 +90,7 @@ The TIFF decoder code is derived from the following:
    limitations under the License.
 
 ==============================================================================
-   
+
 The OpenEXR decoder is derived in part from the OpenEXR library:
 
 Copyright (c) 2002-2011, Industrial Light & Magic, a division of 


### PR DESCRIPTION
Whitespace in the LICENSE file is causing an exception to be thrown in the Flutter LicenseEntryWithLineBreaks.getParagraph() method in licenses.dart. The assertion that fails is on line 160 in src/foundation/licenses.dart:
```
assert(result.text.trimLeft() == result.text);
```
I have no idea what they are checking for with that assertion, but I do know that extraneous whitespace in LICENSE is causing an AssertionException when one calls showAboutDialog() and the image plugin is present.