### PR TITLE
GIF samplingFactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.5
+
+* Added the `samplingFactor` parameter to GIF encoding, which allows to significantly speed up
+  encoding times of GIF encoding. 
+
 ## 2.1.4 - June 01, 2019
 
 - Optimize fillRect, drawPixel, and other drawing functions when opaque colors are used.

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:image/image.dart';
+
 void main() {
   // Read an image from file (webp in this case).
   // decodeImage will identify the format of the image and use the appropriate

--- a/example/image_isolate.dart
+++ b/example/image_isolate.dart
@@ -23,8 +23,8 @@ void decode(DecodeParam param) {
 void main() async {
   ReceivePort receivePort = ReceivePort();
 
-  await Isolate.spawn(decode,
-      new DecodeParam(new File('test.webp'), receivePort.sendPort));
+  await Isolate.spawn(
+      decode, new DecodeParam(new File('test.webp'), receivePort.sendPort));
 
   // Get the processed image from the isolate.
   Image image = await receivePort.first as Image;

--- a/lib/src/animation.dart
+++ b/lib/src/animation.dart
@@ -5,6 +5,7 @@ import 'image.dart';
 enum FrameType {
   /// The frames of this document are to be interpreted as animation.
   animation,
+
   /// The frames of this document are to be interpreted as pages of a document.
   page
 }

--- a/lib/src/bitmap_font.dart
+++ b/lib/src/bitmap_font.dart
@@ -11,8 +11,7 @@ BitmapFont readFontZip(List<int> bytes) => BitmapFont.fromZip(bytes);
 
 /// Decode a [BitmapFont] from the contents of [font] definition (.fnt) file,
 /// and an [Image] that stores the font [map].
-BitmapFont readFont(String font, Image map) =>
-    BitmapFont.fromFnt(font, map);
+BitmapFont readFont(String font, Image map) => BitmapFont.fromFnt(font, map);
 
 /// A bitmap font that can be used with [drawString] and [drawChar] functions.
 /// You can generate a font files from a program
@@ -104,12 +103,10 @@ class BitmapFont {
     return characters[c].xadvance;
   }
 
-  Iterable<XmlElement> _childElements(XmlNode n) => n.children
-      .where((c) => c is XmlElement)
-      .map((c) => c as XmlElement);
+  Iterable<XmlElement> _childElements(XmlNode n) =>
+      n.children.where((c) => c is XmlElement).map((c) => c as XmlElement);
 
-  void _parseFnt(XmlDocument xml, Map<int, Image> fontPages,
-      [Archive arc]) {
+  void _parseFnt(XmlDocument xml, Map<int, Image> fontPages, [Archive arc]) {
     if (xml.children.length != 1) {
       throw ImageException('Invalid font XML');
     }
@@ -206,7 +203,8 @@ class BitmapFont {
                   '$filename');
             }
 
-            Image image = PngDecoder().decodeImage(imageFile.content as List<int>);
+            Image image =
+                PngDecoder().decodeImage(imageFile.content as List<int>);
 
             fontPages[id] = image;
           }
@@ -322,8 +320,7 @@ class BitmapFont {
     }
 
     if (kerningsAttrs != null || kerningList.isNotEmpty) {
-      var node = XmlElement(
-          XmlName('kernings'), kerningsAttrs, kerningList);
+      var node = XmlElement(XmlName('kernings'), kerningsAttrs, kerningList);
       children.add(node);
     }
 

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -6,12 +6,16 @@ import 'internal/clamp.dart';
 enum Channel {
   /// Red channel of a color.
   red,
+
   /// Green channel of a color.
   green,
+
   /// Blue channel of a color.
   blue,
+
   /// Alpha channel of a color.
   alpha,
+
   /// Luminance (brightness) of a color.
   luminance
 }
@@ -90,21 +94,23 @@ int getColor(int r, int g, int b, [int a = 255]) =>
     (clamp255(r));
 
 /// Get the [channel] from the [color].
-int getChannel(int color, Channel channel) =>
-    channel == Channel.red ? getRed(color)
-    : channel == Channel.green ? getGreen(color)
-    : channel == Channel.blue ? getBlue(color)
-    : channel == Channel.alpha ? getAlpha(color)
-    : getLuminance(color);
+int getChannel(int color, Channel channel) => channel == Channel.red
+    ? getRed(color)
+    : channel == Channel.green
+        ? getGreen(color)
+        : channel == Channel.blue
+            ? getBlue(color)
+            : channel == Channel.alpha ? getAlpha(color) : getLuminance(color);
 
 /// Returns a new color, where the given [color]'s [channel] has been
 /// replaced with the given [value].
-int setChannel(int color, Channel channel, int value) =>
-    channel == Channel.red ? setRed(color, value)
-    : channel == Channel.green ? setGreen(color, value)
-    : channel == Channel.blue ? setBlue(color, value)
-    : channel == Channel.alpha ? setAlpha(color, value)
-    : color;
+int setChannel(int color, Channel channel, int value) => channel == Channel.red
+    ? setRed(color, value)
+    : channel == Channel.green
+        ? setGreen(color, value)
+        : channel == Channel.blue
+            ? setBlue(color, value)
+            : channel == Channel.alpha ? setAlpha(color, value) : color;
 
 /// Get the red channel from the [color].
 int getRed(int color) => (color) & 0xff;
@@ -203,8 +209,9 @@ List<int> hslToRgb(num hue, num saturation, num lightness) {
     return p;
   }
 
-  var q = lightness < 0.5 ? lightness * (1.0 + saturation)
-          : lightness + saturation - lightness * saturation;
+  var q = lightness < 0.5
+      ? lightness * (1.0 + saturation)
+      : lightness + saturation - lightness * saturation;
   var p = 2.0 * lightness - q;
 
   var r = hue2rgb(p, q, hue + 1.0 / 3.0);

--- a/lib/src/draw/draw_image.dart
+++ b/lib/src/draw/draw_image.dart
@@ -13,8 +13,16 @@ import 'draw_pixel.dart';
 /// The coordinates refer to the upper left corner. This function can be used to
 /// copy regions within the same image (if [dst] is the same as [src])
 /// but if the regions overlap the results will be unpredictable.
-Image drawImage(Image dst, Image src, {int dstX, int dstY, int dstW, int dstH,
-  int srcX, int srcY, int srcW, int srcH, bool blend = true}) {
+Image drawImage(Image dst, Image src,
+    {int dstX,
+    int dstY,
+    int dstW,
+    int dstH,
+    int srcX,
+    int srcY,
+    int srcW,
+    int srcH,
+    bool blend = true}) {
   if (dstX == null) {
     dstX = 0;
   }
@@ -50,8 +58,8 @@ Image drawImage(Image dst, Image src, {int dstX, int dstY, int dstW, int dstH,
 
   for (int y = 0; y < dstH; ++y) {
     for (int x = 0; x < dstW; ++x) {
-      int stepX = (x * (srcW/dstW)).toInt();
-      int stepY = (y * (srcH/dstH)).toInt();
+      int stepX = (x * (srcW / dstW)).toInt();
+      int stepY = (y * (srcH / dstH)).toInt();
 
       final srcPixel = src.getPixel(srcX + stepX, srcY + stepY);
       if (blend) {

--- a/lib/src/draw/draw_line.dart
+++ b/lib/src/draw/draw_line.dart
@@ -9,7 +9,7 @@ import 'draw_pixel.dart';
 /// If [antialias] is true then the line is drawn with smooth edges.
 /// [thickness] determines how thick the line should be drawn, in pixels.
 Image drawLine(Image image, int x1, int y1, int x2, int y2, int color,
-               {bool antialias = false, num thickness = 1}) {
+    {bool antialias = false, num thickness = 1}) {
   List<int> line = [x1, y1, x2, y2];
   if (!clipLine(line, [0, 0, image.width - 1, image.height - 1])) {
     return image;
@@ -200,9 +200,7 @@ Image drawLine(Image image, int x1, int y1, int x2, int y2, int color,
 
   // Antialias Line
 
-  num ag = (dy.abs() < dx.abs())
-      ? cos(atan2(dy, dx))
-      : sin(atan2(dy, dx));
+  num ag = (dy.abs() < dx.abs()) ? cos(atan2(dy, dx)) : sin(atan2(dy, dx));
 
   int wid;
   if (ag != 0.0) {

--- a/lib/src/draw/fill_flood.dart
+++ b/lib/src/draw/fill_flood.dart
@@ -26,18 +26,16 @@ Image fillFlood(Image src, int x, int y, int color,
 
     array = (int y, int x) {
       return visited[y * src.width + x] == 0 &&
-             _testPixelLabColorDistance(src, x, y, lab, threshold);
+          _testPixelLabColorDistance(src, x, y, lab, threshold);
     };
-
   } else if (!compareAlpha) {
     array = (int y, int x) {
       return visited[y * src.width + x] == 0 &&
-             setAlpha(src.getPixel(x, y), 0) != srcColor;
+          setAlpha(src.getPixel(x, y), 0) != srcColor;
     };
   } else {
     array = (int y, int x) {
-      return visited[y * src.width + x] == 0 &&
-             src.getPixel(x, y) != srcColor;
+      return visited[y * src.width + x] == 0 && src.getPixel(x, y) != srcColor;
     };
   }
 
@@ -75,13 +73,13 @@ Uint8List maskFlood(Image src, int x, int y,
     array = (int y, int x) {
       return visited[y * src.width + x] == 0 &&
           (ret[y * src.width + x] != 0 ||
-           _testPixelLabColorDistance(src, x, y, lab, threshold));
+              _testPixelLabColorDistance(src, x, y, lab, threshold));
     };
   } else if (!compareAlpha) {
     array = (int y, int x) {
       return visited[y * src.width + x] == 0 &&
           (ret[y * src.width + x] != 0 ||
-           setAlpha(src.getPixel(x, y), 0) != srcColor);
+              setAlpha(src.getPixel(x, y), 0) != srcColor);
     };
   } else {
     array = (int y, int x) {
@@ -99,8 +97,8 @@ Uint8List maskFlood(Image src, int x, int y,
   return ret;
 }
 
-bool _testPixelLabColorDistance(Image src, int x, int y, List<num> refColor,
-                                num threshold) {
+bool _testPixelLabColorDistance(
+    Image src, int x, int y, List<num> refColor, num threshold) {
   int pixel = src.getPixel(x, y);
   bool compareAlpha = refColor.length > 3;
   var pixelColor = rgbToLab(getRed(pixel), getGreen(pixel), getBlue(pixel));
@@ -114,7 +112,7 @@ bool _testPixelLabColorDistance(Image src, int x, int y, List<num> refColor,
 // Adam Milazzo (2015). A More Efficient Flood Fill.
 // http://www.adammil.net/blog/v126_A_More_Efficient_Flood_Fill.html
 void _fill4(Image src, int x, int y, _TestPixel array, _MarkPixel mark,
-            Uint8List visited) {
+    Uint8List visited) {
   if (visited[y * src.width + x] == 1) {
     return;
   }
@@ -141,7 +139,7 @@ void _fill4(Image src, int x, int y, _TestPixel array, _MarkPixel mark,
 }
 
 void _fill4Core(Image src, int x, int y, _TestPixel array, _MarkPixel mark,
-                Uint8List visited) {
+    Uint8List visited) {
   if (visited[y * src.width + x] == 1) {
     return;
   }
@@ -210,7 +208,7 @@ void _fill4Core(Image src, int x, int y, _TestPixel array, _MarkPixel mark,
     // of the single cell at the end of the second row, i.e. at (4,1)
     if (rowLength < lastRowLength) {
       // 'end' is the end of the previous row, so scan the current row to
-      for (int end = x + lastRowLength; ++sx < end; ) {
+      for (int end = x + lastRowLength; ++sx < end;) {
         // there. any clear cells would have been connected to the previous
         if (!array(y, sx)) {
           // row. the cells up and left must be set so use FillCore

--- a/lib/src/effects/drop_shadow.dart
+++ b/lib/src/effects/drop_shadow.dart
@@ -7,7 +7,7 @@ import '../transform/copy_into.dart';
 
 /// Create a drop-shadow effect for the image.
 Image dropShadow(Image src, int hShadow, int vShadow, int blur,
-                 {int shadowColor = 0xa0000000}) {
+    {int shadowColor = 0xa0000000}) {
   if (blur < 0) {
     blur = 0;
   }
@@ -47,8 +47,8 @@ Image dropShadow(Image src, int hShadow, int vShadow, int blur,
 
   copyInto(dst, src, dstX: shadowOffsetX, dstY: shadowOffsetY);
 
-  remapColors(dst, red: Channel.alpha, green: Channel.alpha,
-      blue: Channel.alpha);
+  remapColors(dst,
+      red: Channel.alpha, green: Channel.alpha, blue: Channel.alpha);
 
   scaleRgba(dst, getRed(shadowColor), getGreen(shadowColor),
       getBlue(shadowColor), getAlpha(shadowColor));

--- a/lib/src/filter/adjust_color.dart
+++ b/lib/src/filter/adjust_color.dart
@@ -40,7 +40,7 @@ import '../internal/clamp.dart';
 /// [amount] controls how much affect this filter has on the [src] image, where
 /// 0.0 has no effect and 1.0 has full effect.
 Image adjustColor(Image src,
-   {int blacks,
+    {int blacks,
     int whites,
     int mids,
     num contrast,

--- a/lib/src/filter/color_offset.dart
+++ b/lib/src/filter/color_offset.dart
@@ -4,7 +4,7 @@ import '../internal/clamp.dart';
 /// Add the [red], [green], [blue] and [alpha] values to the [src] image
 /// colors, a per-channel brightness.
 Image colorOffset(Image src,
-                 {int red = 0, int green = 0, int blue = 0, int alpha = 0}) {
+    {int red = 0, int green = 0, int blue = 0, int alpha = 0}) {
   var pixels = src.getBytes();
   for (int i = 0, len = pixels.length; i < len; i += 4) {
     pixels[i] = clamp255(pixels[i] + red);

--- a/lib/src/filter/convolution.dart
+++ b/lib/src/filter/convolution.dart
@@ -9,7 +9,7 @@ import '../image.dart';
 /// The rgb channels will be divided by [filterDiv] and add [offset], allowing
 /// filters to normalize and offset the filtered pixel value.
 Image convolution(Image src, List<num> filter,
-                  {num div = 1.0, num offset = 0.0}) {
+    {num div = 1.0, num offset = 0.0}) {
   Image tmp = Image.from(src);
 
   for (int y = 0; y < src.height; ++y) {

--- a/lib/src/filter/emboss.dart
+++ b/lib/src/filter/emboss.dart
@@ -3,11 +3,7 @@ import 'convolution.dart';
 
 /// Apply an emboss convolution filter.
 Image emboss(Image src) {
-  const filter = [
-    1.5, 0.0, 0.0,
-    0.0, 0.0, 0.0,
-    0.0, 0.0, -1.5
-  ];
+  const filter = [1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.5];
 
   return convolution(src, filter, div: 1, offset: 127);
 }

--- a/lib/src/filter/noise.dart
+++ b/lib/src/filter/noise.dart
@@ -5,21 +5,14 @@ import '../image.dart';
 import '../util/min_max.dart';
 import '../util/random.dart';
 
-enum NoiseType {
-  gaussian,
-  uniform,
-  salt_pepper,
-  poisson,
-  rice
-}
+enum NoiseType { gaussian, uniform, salt_pepper, poisson, rice }
 
 /// Add random noise to pixel values. [sigma] determines how strong the effect
 /// should be. [type] should be one of the following: [NoiseType.gaussian],
 /// [NoiseType.uniform], [NoiseType.salt_pepper], [NoiseType.poisson],
 /// or [NoiseType.rice].
 Image noise(Image image, num sigma,
-           {NoiseType type = NoiseType.gaussian,
-            Random random}) {
+    {NoiseType type = NoiseType.gaussian, Random random}) {
   if (random == null) {
     random = Random();
   }

--- a/lib/src/filter/pixelate.dart
+++ b/lib/src/filter/pixelate.dart
@@ -5,6 +5,7 @@ import '../draw/fill_rect.dart';
 enum PixelateMode {
   /// Use the top-left pixel of a block for the block color.
   upperLeft,
+
   /// Use the average of the pixels within a block for the block color.
   average
 }
@@ -16,7 +17,7 @@ enum PixelateMode {
 /// will be used for the block color. Otherwise if [mode] is [PixelateMode.average],
 /// the average of all the pixels in the block will be used for the block color.
 Image pixelate(Image src, int blockSize,
-              {PixelateMode mode = PixelateMode.upperLeft}) {
+    {PixelateMode mode = PixelateMode.upperLeft}) {
   if (blockSize <= 1) {
     return src;
   }

--- a/lib/src/filter/quantize.dart
+++ b/lib/src/filter/quantize.dart
@@ -6,8 +6,9 @@ import '../util/neural_quantizer.dart';
 enum QuantizeMethod { neuralNet, octree }
 
 /// Quantize the number of colors in image to 256.
-Image quantize(Image src, {int numberOfColors = 256,
-               QuantizeMethod method = QuantizeMethod.neuralNet}) {
+Image quantize(Image src,
+    {int numberOfColors = 256,
+    QuantizeMethod method = QuantizeMethod.neuralNet}) {
   if (method == QuantizeMethod.octree || numberOfColors < 4) {
     OctreeQuantizer oct = OctreeQuantizer(src, numberOfColors: numberOfColors);
     for (int i = 0, len = src.length; i < len; ++i) {

--- a/lib/src/filter/remap_colors.dart
+++ b/lib/src/filter/remap_colors.dart
@@ -10,10 +10,10 @@ import '../image.dart';
 /// remapColors(src, alpha: Channel.luminance)
 /// will set the alpha channel to the luminance (grayscale) of the image.
 Image remapColors(Image src,
-    { Channel red = Channel.red,
-      Channel green = Channel.green,
-      Channel blue = Channel.blue,
-      Channel alpha = Channel.alpha}) {
+    {Channel red = Channel.red,
+    Channel green = Channel.green,
+    Channel blue = Channel.blue,
+    Channel alpha = Channel.alpha}) {
   List<int> l = [0, 0, 0, 0, 0];
   var p = src.getBytes();
   for (int i = 0, len = p.length; i < len; i += 4) {

--- a/lib/src/filter/separable_kernel.dart
+++ b/lib/src/filter/separable_kernel.dart
@@ -8,8 +8,8 @@ class SeparableKernel {
 
   /// Create a separable convolution kernel for the given [radius].
   SeparableKernel(int radius)
-      : coefficients = List<num>(2 * radius + 1)
-      , this.size = radius;
+      : coefficients = List<num>(2 * radius + 1),
+        this.size = radius;
 
   /// Get the number of coefficients in the kernel.
   int get length => coefficients.length;
@@ -55,8 +55,8 @@ class SeparableKernel {
     return x;
   }
 
-  void _applyCoeffsLine(Image src, Image dst, int y, int width,
-                        bool horizontal) {
+  void _applyCoeffsLine(
+      Image src, Image dst, int y, int width, bool horizontal) {
     for (int x = 0; x < width; x++) {
       num r = 0.0;
       num g = 0.0;

--- a/lib/src/filter/smooth.dart
+++ b/lib/src/filter/smooth.dart
@@ -6,8 +6,6 @@ import 'convolution.dart';
 /// [w] is the weight of the current pixel being filtered. If it's greater than
 /// 1.0, it will make the image sharper.
 Image smooth(Image src, num w) {
-  var filter = [1.0, 1.0, 1.0,
-                1.0, w.toDouble(), 1.0,
-                1.0, 1.0, 1.0];
+  var filter = [1.0, 1.0, 1.0, 1.0, w.toDouble(), 1.0, 1.0, 1.0, 1.0];
   return convolution(src, filter, div: w + 8, offset: 0);
 }

--- a/lib/src/filter/vignette.dart
+++ b/lib/src/filter/vignette.dart
@@ -14,8 +14,7 @@ num _smoothStep(num edge0, num edge1, num x) {
   return x * x * (3.0 - 2.0 * x);
 }
 
-Image vignette(Image src,
-    {num start = 0.3, num end = 0.75, num amount = 0.8}) {
+Image vignette(Image src, {num start = 0.3, num end = 0.75, num amount = 0.8}) {
   final int h = src.height - 1;
   final int w = src.width - 1;
   num invAmt = 1.0 - amount;

--- a/lib/src/formats/formats.dart
+++ b/lib/src/formats/formats.dart
@@ -240,13 +240,31 @@ Animation decodeGifAnimation(List<int> bytes) {
 }
 
 /// Encode an image to the GIF format.
-List<int> encodeGif(Image image) {
-  return new GifEncoder().encodeImage(image);
+///
+/// The [samplingFactor] specifies the sampling factor for
+/// NeuQuant image quantization. It is responsible for reducing
+/// the amount of unique colors in your images to 256.
+/// According to https://scientificgems.wordpress.com/stuff/neuquant-fast-high-quality-image-quantization/,
+/// a sampling factor 10 gives you a reasonable trade-off between image quality
+/// and quantization speed.
+/// If you know that you have less than 256 colors in your frames
+/// anyway, you should supply a very large [samplingFactor] for maximum performance.
+List<int> encodeGif(Image image, {int samplingFactor = 30}) {
+  return GifEncoder(samplingFactor: samplingFactor).encodeImage(image);
 }
 
 /// Encode an animation to the GIF format.
-List<int> encodeGifAnimation(Animation anim) {
-  return new GifEncoder().encodeAnimation(anim);
+///
+/// The [samplingFactor] specifies the sampling factor for
+/// NeuQuant image quantization. It is responsible for reducing
+/// the amount of unique colors in your images to 256.
+/// According to https://scientificgems.wordpress.com/stuff/neuquant-fast-high-quality-image-quantization/,
+/// a sampling factor 10 gives you a reasonable trade-off between image quality
+/// and quantization speed.
+/// If you know that you have less than 256 colors in your frames
+/// anyway, you should supply a very large [samplingFactor] for maximum performance.
+List<int> encodeGifAnimation(Animation anim, {int samplingFactor = 30}) {
+  return GifEncoder(samplingFactor: samplingFactor).encodeAnimation(anim);
 }
 
 /// Decode a TIFF formatted image.

--- a/lib/src/formats/jpeg_encoder.dart
+++ b/lib/src/formats/jpeg_encoder.dart
@@ -74,11 +74,13 @@ class JpegEncoder extends Encoder {
           int col = (pos & 7) * 4; // % 8
           int p = start + (row * quadWidth) + col;
 
-          if (y + row >= height) { // padding bottom
+          if (y + row >= height) {
+            // padding bottom
             p -= (quadWidth * (y + 1 + row - height));
           }
 
-          if (x + col >= quadWidth) { // padding right
+          if (x + col >= quadWidth) {
+            // padding right
             p -= ((x + col) - quadWidth + 4);
           }
 
@@ -88,16 +90,22 @@ class JpegEncoder extends Encoder {
 
           // calculate YUV values
           YDU[pos] = ((RGB_YUV_TABLE[r] +
-                       RGB_YUV_TABLE[(g +  256)] +
-                       RGB_YUV_TABLE[(b +  512)]) >> 16) - 128.0;
+                      RGB_YUV_TABLE[(g + 256)] +
+                      RGB_YUV_TABLE[(b + 512)]) >>
+                  16) -
+              128.0;
 
-          UDU[pos] = ((RGB_YUV_TABLE[(r +  768)] +
-                       RGB_YUV_TABLE[(g + 1024)] +
-                       RGB_YUV_TABLE[(b + 1280)]) >> 16) - 128.0;
+          UDU[pos] = ((RGB_YUV_TABLE[(r + 768)] +
+                      RGB_YUV_TABLE[(g + 1024)] +
+                      RGB_YUV_TABLE[(b + 1280)]) >>
+                  16) -
+              128.0;
 
           VDU[pos] = ((RGB_YUV_TABLE[(r + 1280)] +
-                       RGB_YUV_TABLE[(g + 1536)] +
-                       RGB_YUV_TABLE[(b + 1792)]) >> 16) - 128.0;
+                      RGB_YUV_TABLE[(g + 1536)] +
+                      RGB_YUV_TABLE[(b + 1792)]) >>
+                  16) -
+              128.0;
         }
 
         DCY = _processDU(fp, YDU, fdtbl_Y, DCY, YDC_HT, YAC_HT);
@@ -130,14 +138,71 @@ class JpegEncoder extends Encoder {
 
   void _initQuantTables(int sf) {
     const List<int> YQT = const [
-        16, 11, 10, 16, 24, 40, 51, 61,
-        12, 12, 14, 19, 26, 58, 60, 55,
-        14, 13, 16, 24, 40, 57, 69, 56,
-        14, 17, 22, 29, 51, 87, 80, 62,
-        18, 22, 37, 56, 68,109,103, 77,
-        24, 35, 55, 64, 81,104,113, 92,
-        49, 64, 78, 87,103,121,120,101,
-        72, 92, 95, 98,112,100,103, 99 ];
+      16,
+      11,
+      10,
+      16,
+      24,
+      40,
+      51,
+      61,
+      12,
+      12,
+      14,
+      19,
+      26,
+      58,
+      60,
+      55,
+      14,
+      13,
+      16,
+      24,
+      40,
+      57,
+      69,
+      56,
+      14,
+      17,
+      22,
+      29,
+      51,
+      87,
+      80,
+      62,
+      18,
+      22,
+      37,
+      56,
+      68,
+      109,
+      103,
+      77,
+      24,
+      35,
+      55,
+      64,
+      81,
+      104,
+      113,
+      92,
+      49,
+      64,
+      78,
+      87,
+      103,
+      121,
+      120,
+      101,
+      72,
+      92,
+      95,
+      98,
+      112,
+      100,
+      103,
+      99
+    ];
 
     for (int i = 0; i < 64; i++) {
       int t = ((YQT[i] * sf + 50) / 100).floor();
@@ -150,14 +215,71 @@ class JpegEncoder extends Encoder {
     }
 
     const List<int> UVQT = const [
-        17, 18, 24, 47, 99, 99, 99, 99,
-        18, 21, 26, 66, 99, 99, 99, 99,
-        24, 26, 56, 99, 99, 99, 99, 99,
-        47, 66, 99, 99, 99, 99, 99, 99,
-        99, 99, 99, 99, 99, 99, 99, 99,
-        99, 99, 99, 99, 99, 99, 99, 99,
-        99, 99, 99, 99, 99, 99, 99, 99,
-        99, 99, 99, 99, 99, 99, 99, 99 ];
+      17,
+      18,
+      24,
+      47,
+      99,
+      99,
+      99,
+      99,
+      18,
+      21,
+      26,
+      66,
+      99,
+      99,
+      99,
+      99,
+      24,
+      26,
+      56,
+      99,
+      99,
+      99,
+      99,
+      99,
+      47,
+      66,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99,
+      99
+    ];
 
     for (int j = 0; j < 64; j++) {
       int u = ((UVQT[j] * sf + 50) / 100).floor();
@@ -170,14 +292,22 @@ class JpegEncoder extends Encoder {
     }
 
     const List<double> aasf = const [
-        1.0, 1.387039845, 1.306562965, 1.175875602,
-        1.0, 0.785694958, 0.541196100, 0.275899379 ];
+      1.0,
+      1.387039845,
+      1.306562965,
+      1.175875602,
+      1.0,
+      0.785694958,
+      0.541196100,
+      0.275899379
+    ];
 
     int k = 0;
     for (int row = 0; row < 8; row++) {
       for (int col = 0; col < 8; col++) {
         fdtbl_Y[k] = (1.0 / (YTable[ZIGZAG[k]] * aasf[row] * aasf[col] * 8.0));
-        fdtbl_UV[k] = (1.0 / (UVTable[ZIGZAG[k]] * aasf[row] * aasf[col] * 8.0));
+        fdtbl_UV[k] =
+            (1.0 / (UVTable[ZIGZAG[k]] * aasf[row] * aasf[col] * 8.0));
         k++;
       }
     }
@@ -203,14 +333,14 @@ class JpegEncoder extends Encoder {
   }
 
   void _initHuffmanTbl() {
-    YDC_HT = _computeHuffmanTbl(STD_DC_LUMINANCE_NR_CODES,
-                                STD_DC_LUMINANCE_VALUES);
-    UVDC_HT = _computeHuffmanTbl(STD_DC_CHROMINANCE_NR_CODES,
-                                 STD_DC_CHROMINANCE_VALUES);
-    YAC_HT = _computeHuffmanTbl(STD_AC_LUMINANCE_NR_CODES,
-                                STD_AC_LUMINANCE_VALUES);
-    UVAC_HT = _computeHuffmanTbl(STD_AC_CHROMINANCE_NR_CODES,
-                                 STD_AC_CHROMINANCE_VALUES);
+    YDC_HT =
+        _computeHuffmanTbl(STD_DC_LUMINANCE_NR_CODES, STD_DC_LUMINANCE_VALUES);
+    UVDC_HT = _computeHuffmanTbl(
+        STD_DC_CHROMINANCE_NR_CODES, STD_DC_CHROMINANCE_VALUES);
+    YAC_HT =
+        _computeHuffmanTbl(STD_AC_LUMINANCE_NR_CODES, STD_AC_LUMINANCE_VALUES);
+    UVAC_HT = _computeHuffmanTbl(
+        STD_AC_CHROMINANCE_NR_CODES, STD_AC_CHROMINANCE_VALUES);
   }
 
   void _initCategoryNumber() {
@@ -239,7 +369,7 @@ class JpegEncoder extends Encoder {
       RGB_YUV_TABLE[(i + 512)] = 7471 * i + 0x8000;
       RGB_YUV_TABLE[(i + 768)] = -11059 * i;
       RGB_YUV_TABLE[(i + 1024)] = -21709 * i;
-      RGB_YUV_TABLE[(i + 1280)] =  32768 * i + 0x807FFF;
+      RGB_YUV_TABLE[(i + 1280)] = 32768 * i + 0x807FFF;
       RGB_YUV_TABLE[(i + 1536)] = -27439 * i;
       RGB_YUV_TABLE[(i + 1792)] = -5329 * i;
     }
@@ -327,7 +457,7 @@ class JpegEncoder extends Encoder {
       double tmp4p2 = d3 - d4;
 
       // Even part
-      double tmp10p2 = tmp0p2 + tmp3p2;        // phase 2
+      double tmp10p2 = tmp0p2 + tmp3p2; // phase 2
       double tmp13p2 = tmp0p2 - tmp3p2;
       double tmp11p2 = tmp1p2 + tmp2p2;
       double tmp12p2 = tmp1p2 - tmp2p2;
@@ -350,7 +480,7 @@ class JpegEncoder extends Encoder {
       double z4p2 = 1.306562965 * tmp12p2 + z5p2; // c2 + c6
       double z3p2 = tmp11p2 * 0.707106781; // c4
 
-      double z11p2 = tmp7p2 + z3p2;        // phase 5
+      double z11p2 = tmp7p2 + z3p2; // phase 5
       double z13p2 = tmp7p2 - z3p2;
 
       data[dataOff + 40] = z13p2 + z2p2; // phase 6
@@ -365,9 +495,9 @@ class JpegEncoder extends Encoder {
     for (int i = 0; i < I64; ++i) {
       // Apply the quantization and scaling factor & Round to nearest integer
       double fDCTQuant = data[i] * fdtbl[i];
-      outputfDCTQuant[i] = (fDCTQuant > 0.0) ?
-                           ((fDCTQuant + 0.5).toInt()) :
-                           ((fDCTQuant - 0.5).toInt());
+      outputfDCTQuant[i] = (fDCTQuant > 0.0)
+          ? ((fDCTQuant + 0.5).toInt())
+          : ((fDCTQuant - 0.5).toInt());
     }
 
     return outputfDCTQuant;
@@ -485,8 +615,8 @@ class JpegEncoder extends Encoder {
     out.writeByte(0); // Bf
   }
 
-  int _processDU(OutputBuffer out, List<double> CDU, List<double> fdtbl,
-                 int DC, List<List<int>> HTDC, List<List<int>> HTAC) {
+  int _processDU(OutputBuffer out, List<double> CDU, List<double> fdtbl, int DC,
+      List<List<int>> HTDC, List<List<int>> HTAC) {
     List<int> EOB = HTAC[0x00];
     List<int> M16zeroes = HTAC[0xF0];
     int pos;
@@ -513,9 +643,10 @@ class JpegEncoder extends Encoder {
 
     // Encode ACs
     int end0pos = 63;
-    for (; (end0pos > 0) && (DU[end0pos] == 0); end0pos--) {};
+    for (; (end0pos > 0) && (DU[end0pos] == 0); end0pos--) {}
+    ;
     //end0pos = first element in reverse order !=0
-    if ( end0pos == 0) {
+    if (end0pos == 0) {
       _writeBits(out, EOB);
       return DC;
     }
@@ -524,8 +655,7 @@ class JpegEncoder extends Encoder {
     int lng;
     while (i <= end0pos) {
       int startpos = i;
-      for (; (DU[i] == 0) && (i <= end0pos); ++i) {
-      }
+      for (; (DU[i] == 0) && (i <= end0pos); ++i) {}
 
       int nrzeroes = i - startpos;
       if (nrzeroes >= I16) {
@@ -596,78 +726,511 @@ class JpegEncoder extends Encoder {
   int currentQuality;
 
   static const List<int> ZIGZAG = const [
-       0, 1, 5, 6,14,15,27,28,
-       2, 4, 7,13,16,26,29,42,
-       3, 8,12,17,25,30,41,43,
-       9,11,18,24,31,40,44,53,
-      10,19,23,32,39,45,52,54,
-      20,22,33,38,46,51,55,60,
-      21,34,37,47,50,56,59,61,
-      35,36,48,49,57,58,62,63 ];
+    0,
+    1,
+    5,
+    6,
+    14,
+    15,
+    27,
+    28,
+    2,
+    4,
+    7,
+    13,
+    16,
+    26,
+    29,
+    42,
+    3,
+    8,
+    12,
+    17,
+    25,
+    30,
+    41,
+    43,
+    9,
+    11,
+    18,
+    24,
+    31,
+    40,
+    44,
+    53,
+    10,
+    19,
+    23,
+    32,
+    39,
+    45,
+    52,
+    54,
+    20,
+    22,
+    33,
+    38,
+    46,
+    51,
+    55,
+    60,
+    21,
+    34,
+    37,
+    47,
+    50,
+    56,
+    59,
+    61,
+    35,
+    36,
+    48,
+    49,
+    57,
+    58,
+    62,
+    63
+  ];
 
   static const List<int> STD_DC_LUMINANCE_NR_CODES = const [
-      0, 0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0 ];
+    0,
+    0,
+    1,
+    5,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ];
 
   static const List<int> STD_DC_LUMINANCE_VALUES = const [
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11
+  ];
 
   static const List<int> STD_AC_LUMINANCE_NR_CODES = const [
-      0, 0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 0x7d ];
+    0,
+    0,
+    2,
+    1,
+    3,
+    3,
+    2,
+    4,
+    3,
+    5,
+    5,
+    4,
+    4,
+    0,
+    0,
+    1,
+    0x7d
+  ];
 
   static const List<int> STD_AC_LUMINANCE_VALUES = const [
-      0x01, 0x02, 0x03, 0x00, 0x04, 0x11, 0x05, 0x12,
-      0x21, 0x31, 0x41, 0x06, 0x13, 0x51, 0x61, 0x07,
-      0x22, 0x71, 0x14, 0x32, 0x81, 0x91, 0xa1, 0x08,
-      0x23, 0x42, 0xb1, 0xc1, 0x15, 0x52, 0xd1, 0xf0,
-      0x24, 0x33, 0x62, 0x72, 0x82, 0x09, 0x0a, 0x16,
-      0x17, 0x18, 0x19, 0x1a, 0x25, 0x26, 0x27, 0x28,
-      0x29, 0x2a, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
-      0x3a, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
-      0x4a, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,
-      0x5a, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
-      0x6a, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
-      0x7a, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
-      0x8a, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98,
-      0x99, 0x9a, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
-      0xa8, 0xa9, 0xaa, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6,
-      0xb7, 0xb8, 0xb9, 0xba, 0xc2, 0xc3, 0xc4, 0xc5,
-      0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xd2, 0xd3, 0xd4,
-      0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xe1, 0xe2,
-      0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea,
-      0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
-      0xf9, 0xfa ];
+    0x01,
+    0x02,
+    0x03,
+    0x00,
+    0x04,
+    0x11,
+    0x05,
+    0x12,
+    0x21,
+    0x31,
+    0x41,
+    0x06,
+    0x13,
+    0x51,
+    0x61,
+    0x07,
+    0x22,
+    0x71,
+    0x14,
+    0x32,
+    0x81,
+    0x91,
+    0xa1,
+    0x08,
+    0x23,
+    0x42,
+    0xb1,
+    0xc1,
+    0x15,
+    0x52,
+    0xd1,
+    0xf0,
+    0x24,
+    0x33,
+    0x62,
+    0x72,
+    0x82,
+    0x09,
+    0x0a,
+    0x16,
+    0x17,
+    0x18,
+    0x19,
+    0x1a,
+    0x25,
+    0x26,
+    0x27,
+    0x28,
+    0x29,
+    0x2a,
+    0x34,
+    0x35,
+    0x36,
+    0x37,
+    0x38,
+    0x39,
+    0x3a,
+    0x43,
+    0x44,
+    0x45,
+    0x46,
+    0x47,
+    0x48,
+    0x49,
+    0x4a,
+    0x53,
+    0x54,
+    0x55,
+    0x56,
+    0x57,
+    0x58,
+    0x59,
+    0x5a,
+    0x63,
+    0x64,
+    0x65,
+    0x66,
+    0x67,
+    0x68,
+    0x69,
+    0x6a,
+    0x73,
+    0x74,
+    0x75,
+    0x76,
+    0x77,
+    0x78,
+    0x79,
+    0x7a,
+    0x83,
+    0x84,
+    0x85,
+    0x86,
+    0x87,
+    0x88,
+    0x89,
+    0x8a,
+    0x92,
+    0x93,
+    0x94,
+    0x95,
+    0x96,
+    0x97,
+    0x98,
+    0x99,
+    0x9a,
+    0xa2,
+    0xa3,
+    0xa4,
+    0xa5,
+    0xa6,
+    0xa7,
+    0xa8,
+    0xa9,
+    0xaa,
+    0xb2,
+    0xb3,
+    0xb4,
+    0xb5,
+    0xb6,
+    0xb7,
+    0xb8,
+    0xb9,
+    0xba,
+    0xc2,
+    0xc3,
+    0xc4,
+    0xc5,
+    0xc6,
+    0xc7,
+    0xc8,
+    0xc9,
+    0xca,
+    0xd2,
+    0xd3,
+    0xd4,
+    0xd5,
+    0xd6,
+    0xd7,
+    0xd8,
+    0xd9,
+    0xda,
+    0xe1,
+    0xe2,
+    0xe3,
+    0xe4,
+    0xe5,
+    0xe6,
+    0xe7,
+    0xe8,
+    0xe9,
+    0xea,
+    0xf1,
+    0xf2,
+    0xf3,
+    0xf4,
+    0xf5,
+    0xf6,
+    0xf7,
+    0xf8,
+    0xf9,
+    0xfa
+  ];
 
   static const List<int> STD_DC_CHROMINANCE_NR_CODES = const [
-      0, 0, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0 ];
+    0,
+    0,
+    3,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    0,
+    0,
+    0,
+    0,
+    0
+  ];
 
   static const List<int> STD_DC_CHROMINANCE_VALUES = const [
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11
+  ];
 
   static const List<int> STD_AC_CHROMINANCE_NR_CODES = const [
-      0, 0, 2, 1, 2, 4, 4, 3, 4, 7, 5, 4, 4, 0, 1, 2, 0x77 ];
+    0,
+    0,
+    2,
+    1,
+    2,
+    4,
+    4,
+    3,
+    4,
+    7,
+    5,
+    4,
+    4,
+    0,
+    1,
+    2,
+    0x77
+  ];
 
   static const List<int> STD_AC_CHROMINANCE_VALUES = const [
-      0x00, 0x01, 0x02, 0x03, 0x11, 0x04, 0x05, 0x21,
-      0x31, 0x06, 0x12, 0x41, 0x51, 0x07, 0x61, 0x71,
-      0x13, 0x22, 0x32, 0x81, 0x08, 0x14, 0x42, 0x91,
-      0xa1, 0xb1, 0xc1, 0x09, 0x23, 0x33, 0x52, 0xf0,
-      0x15, 0x62, 0x72, 0xd1, 0x0a, 0x16, 0x24, 0x34,
-      0xe1, 0x25, 0xf1, 0x17, 0x18, 0x19, 0x1a, 0x26,
-      0x27, 0x28, 0x29, 0x2a, 0x35, 0x36, 0x37, 0x38,
-      0x39, 0x3a, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
-      0x49, 0x4a, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
-      0x59, 0x5a, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
-      0x69, 0x6a, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
-      0x79, 0x7a, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
-      0x88, 0x89, 0x8a, 0x92, 0x93, 0x94, 0x95, 0x96,
-      0x97, 0x98, 0x99, 0x9a, 0xa2, 0xa3, 0xa4, 0xa5,
-      0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xb2, 0xb3, 0xb4,
-      0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xc2, 0xc3,
-      0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xd2,
-      0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda,
-      0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9,
-      0xea, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
-      0xf9, 0xfa ];
+    0x00,
+    0x01,
+    0x02,
+    0x03,
+    0x11,
+    0x04,
+    0x05,
+    0x21,
+    0x31,
+    0x06,
+    0x12,
+    0x41,
+    0x51,
+    0x07,
+    0x61,
+    0x71,
+    0x13,
+    0x22,
+    0x32,
+    0x81,
+    0x08,
+    0x14,
+    0x42,
+    0x91,
+    0xa1,
+    0xb1,
+    0xc1,
+    0x09,
+    0x23,
+    0x33,
+    0x52,
+    0xf0,
+    0x15,
+    0x62,
+    0x72,
+    0xd1,
+    0x0a,
+    0x16,
+    0x24,
+    0x34,
+    0xe1,
+    0x25,
+    0xf1,
+    0x17,
+    0x18,
+    0x19,
+    0x1a,
+    0x26,
+    0x27,
+    0x28,
+    0x29,
+    0x2a,
+    0x35,
+    0x36,
+    0x37,
+    0x38,
+    0x39,
+    0x3a,
+    0x43,
+    0x44,
+    0x45,
+    0x46,
+    0x47,
+    0x48,
+    0x49,
+    0x4a,
+    0x53,
+    0x54,
+    0x55,
+    0x56,
+    0x57,
+    0x58,
+    0x59,
+    0x5a,
+    0x63,
+    0x64,
+    0x65,
+    0x66,
+    0x67,
+    0x68,
+    0x69,
+    0x6a,
+    0x73,
+    0x74,
+    0x75,
+    0x76,
+    0x77,
+    0x78,
+    0x79,
+    0x7a,
+    0x82,
+    0x83,
+    0x84,
+    0x85,
+    0x86,
+    0x87,
+    0x88,
+    0x89,
+    0x8a,
+    0x92,
+    0x93,
+    0x94,
+    0x95,
+    0x96,
+    0x97,
+    0x98,
+    0x99,
+    0x9a,
+    0xa2,
+    0xa3,
+    0xa4,
+    0xa5,
+    0xa6,
+    0xa7,
+    0xa8,
+    0xa9,
+    0xaa,
+    0xb2,
+    0xb3,
+    0xb4,
+    0xb5,
+    0xb6,
+    0xb7,
+    0xb8,
+    0xb9,
+    0xba,
+    0xc2,
+    0xc3,
+    0xc4,
+    0xc5,
+    0xc6,
+    0xc7,
+    0xc8,
+    0xc9,
+    0xca,
+    0xd2,
+    0xd3,
+    0xd4,
+    0xd5,
+    0xd6,
+    0xd7,
+    0xd8,
+    0xd9,
+    0xda,
+    0xe2,
+    0xe3,
+    0xe4,
+    0xe5,
+    0xe6,
+    0xe7,
+    0xe8,
+    0xe9,
+    0xea,
+    0xf2,
+    0xf3,
+    0xf4,
+    0xf5,
+    0xf6,
+    0xf7,
+    0xf8,
+    0xf9,
+    0xfa
+  ];
 
   int _bytenew = 0;
   int _bytepos = 7;

--- a/lib/src/formats/png_encoder.dart
+++ b/lib/src/formats/png_encoder.dart
@@ -37,8 +37,8 @@ class PngEncoder extends Encoder {
     }
 
     // Include room for the filter bytes (1 byte per row).
-    var filteredImage =
-        Uint8List((image.width * image.height * image.numberOfChannels) + image.height);
+    var filteredImage = Uint8List(
+        (image.width * image.height * image.numberOfChannels) + image.height);
 
     _filter(image, filteredImage);
 
@@ -342,8 +342,8 @@ class PngEncoder extends Encoder {
       if (image.channels == Channels.rgba) {
         int aa = (x == 0) ? 0 : getAlpha(image.getPixel(x - 1, row));
         int ba = (row == 0) ? 0 : getAlpha(image.getPixel(x, row - 1));
-        int ca = (row == 0 || x == 0) ? 0
-            : getAlpha(image.getPixel(x - 1, row - 1));
+        int ca =
+            (row == 0 || x == 0) ? 0 : getAlpha(image.getPixel(x - 1, row - 1));
         int xa = getAlpha(image.getPixel(x, row));
         int pa = _paethPredictor(aa, ba, ca);
         out[oi++] = (xa - pa) & 0xff;

--- a/lib/src/formats/pvrtc/pvrtc_color.dart
+++ b/lib/src/formats/pvrtc/pvrtc_color.dart
@@ -6,9 +6,9 @@ class PvrtcColorRgb {
   PvrtcColorRgb([this.r = 0, this.g = 0, this.b = 0]);
 
   PvrtcColorRgb.from(PvrtcColorRgb other)
-    : r = other.r
-    , g = other.g
-    , b = other.b;
+      : r = other.r,
+        g = other.g,
+        b = other.b;
 
   PvrtcColorRgb copy() => new PvrtcColorRgb.from(this);
 

--- a/lib/src/formats/pvrtc/pvrtc_color_bounding_box.dart
+++ b/lib/src/formats/pvrtc/pvrtc_color_bounding_box.dart
@@ -3,8 +3,8 @@ class PvrtcColorBoundingBox {
   dynamic max;
 
   PvrtcColorBoundingBox(dynamic min, dynamic max)
-    : this.min = min.copy()
-    , this.max = max.copy();
+      : this.min = min.copy(),
+        this.max = max.copy();
 
   void add(dynamic c) {
     min.setMin(c);

--- a/lib/src/formats/pvrtc/pvrtc_encoder.dart
+++ b/lib/src/formats/pvrtc/pvrtc_encoder.dart
@@ -286,8 +286,8 @@ class PvrtcEncoder {
     return outputData;
   }
 
-  static PvrtcColorBoundingBox _calculateBoundingBoxRgb(Image bitmap,
-      int blockX, int blockY) {
+  static PvrtcColorBoundingBox _calculateBoundingBoxRgb(
+      Image bitmap, int blockX, int blockY) {
     int size = bitmap.width;
     int pi = (blockY * 4 * size + blockX * 4);
 

--- a/lib/src/formats/webp/vp8_filter.dart
+++ b/lib/src/formats/webp/vp8_filter.dart
@@ -628,18 +628,7 @@ class VP8Filter {
     Put8x8uv(0x80, dst);
   }
 
-  static const PredLuma4 = [
-    DC4,
-    TM4,
-    VE4,
-    HE4,
-    RD4,
-    VR4,
-    LD4,
-    VL4,
-    HD4,
-    HU4
-  ];
+  static const PredLuma4 = [DC4, TM4, VE4, HE4, RD4, VR4, LD4, VL4, HD4, HU4];
 
   static const PredLuma16 = [
     DC16,

--- a/lib/src/formats/webp/vp8l.dart
+++ b/lib/src/formats/webp/vp8l.dart
@@ -203,8 +203,8 @@ class VP8L {
     return data;
   }
 
-  bool _decodeImageData(dynamic data, int width, int height, int lastRow,
-                        dynamic processFunc) {
+  bool _decodeImageData(
+      dynamic data, int width, int height, int lastRow, dynamic processFunc) {
     int row = _lastPixel ~/ width;
     int col = _lastPixel % width;
 
@@ -1004,7 +1004,7 @@ class InternalVP8L extends VP8L {
   set ioHeight(int height) => _ioHeight = height;
 
   bool decodeImageData(dynamic data, int width, int height, int lastRow,
-                       dynamic processFunc) =>
+          dynamic processFunc) =>
       _decodeImageData(data, width, height, lastRow, processFunc);
 
   Uint32List decodeImageStream(int xsize, int ysize, bool isLevel0) =>

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -6,25 +6,15 @@ import 'exif_data.dart';
 import 'icc_profile_data.dart';
 import 'util/interpolation.dart';
 
-enum Format {
-  argb,
-  abgr,
-  rgba,
-  bgra,
-  rgb,
-  bgr,
-  luminance
-}
+enum Format { argb, abgr, rgba, bgra, rgb, bgr, luminance }
 
-enum Channels {
-  rgb,
-  rgba
-}
+enum Channels { rgb, rgba }
 
 enum BlendMode {
   /// No alpha blending should be done when drawing this frame (replace
   /// pixels in canvas).
   source,
+
   /// Alpha blending should be used when drawing this frame (composited over
   /// the current canvas image).
   over
@@ -33,8 +23,10 @@ enum BlendMode {
 enum DisposeMode {
   /// When drawing a frame, the canvas should be left as it is.
   none,
+
   /// When drawing a frame, the canvas should be cleared first.
   clear,
+
   /// When drawing this frame, the canvas should be reverted to how it was
   /// before drawing it.
   previous
@@ -103,13 +95,12 @@ class Image {
 
   /// Create an image with the given dimensions and format.
   Image(this.width, this.height,
-        {this.channels = Channels.rgba, ExifData exif, ICCProfileData iccp})
+      {this.channels = Channels.rgba, ExifData exif, ICCProfileData iccp})
       : this.data = Uint32List(width * height),
         this.exif = ExifData.from(exif),
         this.iccProfile = iccp;
 
-  Image.rgb(this.width, this.height,
-      {ExifData exif, ICCProfileData iccp})
+  Image.rgb(this.width, this.height, {ExifData exif, ICCProfileData iccp})
       : this.channels = Channels.rgb,
         this.data = Uint32List(width * height),
         this.exif = ExifData.from(exif),
@@ -148,9 +139,10 @@ class Image {
   /// var image = Image.fromBytes(canvas.width, canvas.height, bytes,
   ///                             format: Format.rgba);
   Image.fromBytes(int width, int height, List<int> bytes,
-                 {ExifData exif, ICCProfileData iccp,
-                 Format format = Format.rgba,
-                 this.channels = Channels.rgba})
+      {ExifData exif,
+      ICCProfileData iccp,
+      Format format = Format.rgba,
+      this.channels = Channels.rgba})
       : this.width = width,
         this.height = height,
         data = _convertData(width, height, bytes, format),
@@ -438,7 +430,8 @@ class Image {
     int _linear(int Icc, int Inc, int Icn, int Inn) {
       return (Icc +
               dx * (Inc - Icc + dy * (Icc + Inn - Icn - Inc)) +
-              dy * (Icn - Icc)).toInt();
+              dy * (Icn - Icc))
+          .toInt();
     }
 
     int Icc = getPixelSafe(x, y);
@@ -469,7 +462,9 @@ class Image {
     var dy = fy - y;
 
     num _cubic(num dx, num Ipp, num Icp, num Inp, num Iap) =>
-        Icp + 0.5 * (dx * (-Ipp + Inp) +
+        Icp +
+        0.5 *
+            (dx * (-Ipp + Inp) +
                 dx * dx * (2 * Ipp - 5 * Icp + 4 * Inp - Iap) +
                 dx * dx * dx * (-Ipp + 3 * Icp - 3 * Inp + Iap));
 
@@ -571,17 +566,16 @@ class Image {
     return (r + g + b) ~/ 3;
   }
 
-  static Uint32List _convertData(int width, int height, List<int> bytes,
-                                 Format format) {
+  static Uint32List _convertData(
+      int width, int height, List<int> bytes, Format format) {
     if (format == Format.rgba) {
       return bytes is Uint32List
           ? Uint32List.fromList(bytes)
           : Uint32List.view(Uint8List.fromList(bytes).buffer);
     }
 
-    List<int> input = bytes is Uint32List
-        ? Uint8List.view(bytes.buffer)
-        : bytes;
+    List<int> input =
+        bytes is Uint32List ? Uint8List.view(bytes.buffer) : bytes;
 
     Uint32List data = Uint32List(width * height);
     Uint8List rgba = Uint8List.view(data.buffer);

--- a/lib/src/internal/clamp.dart
+++ b/lib/src/internal/clamp.dart
@@ -1,4 +1,3 @@
-
 /// Clamp [x] to [a] [b]
 int clamp(int x, int a, int b) => x.clamp(a, b).toInt();
 

--- a/lib/src/transform/copy_crop.dart
+++ b/lib/src/transform/copy_crop.dart
@@ -2,8 +2,8 @@ import '../image.dart';
 
 /// Returns a cropped copy of [src].
 Image copyCrop(Image src, int x, int y, int w, int h) {
-  Image dst = Image(w, h, channels: src.channels, exif: src.exif,
-      iccp: src.iccProfile);
+  Image dst =
+      Image(w, h, channels: src.channels, exif: src.exif, iccp: src.iccProfile);
 
   for (int yi = 0, sy = y; yi < h; ++yi, ++sy) {
     for (int xi = 0, sx = x; xi < w; ++xi, ++sx) {

--- a/lib/src/transform/copy_into.dart
+++ b/lib/src/transform/copy_into.dart
@@ -15,8 +15,13 @@ import '../draw/draw_pixel.dart';
 /// copy regions within the same image (if [dst] is the same as [src])
 /// but if the regions overlap the results will be unpredictable.
 Image copyInto(Image dst, Image src,
-               {int dstX, int dstY, int srcX, int srcY, int srcW, int srcH,
-                bool blend = true}) {
+    {int dstX,
+    int dstY,
+    int srcX,
+    int srcY,
+    int srcW,
+    int srcH,
+    bool blend = true}) {
   if (dstX == null) {
     dstX = 0;
   }

--- a/lib/src/transform/copy_rectify.dart
+++ b/lib/src/transform/copy_rectify.dart
@@ -3,8 +3,12 @@ import '../util/point.dart';
 
 /// Returns a copy of the [src] image, where the given rectangle
 /// has been mapped to the full image.
-Image copyRectify(Image src, {Point topLeft, Point topRight, Point bottomLeft,
-                  Point bottomRight, Image toImage}) {
+Image copyRectify(Image src,
+    {Point topLeft,
+    Point topRight,
+    Point bottomLeft,
+    Point bottomRight,
+    Image toImage}) {
   Image dst = toImage == null ? Image.from(src) : toImage;
   for (int y = 0; y < dst.height; ++y) {
     double v = y / (dst.height - 1);

--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -11,8 +11,10 @@ import 'bake_orientation.dart';
 /// ratio of [src] and [width].
 /// If [width] isn't specified, then it will be determined by the aspect ratio
 /// of [src] and [height].
-Image copyResize(Image src, {int width, int height,
-                  Interpolation interpolation = Interpolation.nearest}) {
+Image copyResize(Image src,
+    {int width,
+    int height,
+    Interpolation interpolation = Interpolation.nearest}) {
   if (width == null && height == null) {
     throw ImageException('Invalid size');
   }
@@ -31,8 +33,8 @@ Image copyResize(Image src, {int width, int height,
     return src.clone();
   }
 
-  Image dst = Image(width, height, channels: src.channels, exif: src.exif,
-      iccp: src.iccProfile);
+  Image dst = Image(width, height,
+      channels: src.channels, exif: src.exif, iccp: src.iccProfile);
 
   double dy = src.height / height;
   double dx = src.width / width;

--- a/lib/src/transform/copy_resize_crop_square.dart
+++ b/lib/src/transform/copy_resize_crop_square.dart
@@ -11,15 +11,14 @@ Image copyResizeCropSquare(Image src, int size) {
 
   int height = size;
   int width = size;
-  if (src.width < src.height){
+  if (src.width < src.height) {
     height = (size * (src.height / src.width)).toInt();
-  }
-  else if (src.width > src.height){
+  } else if (src.width > src.height) {
     width = (size * (src.width / src.height)).toInt();
   }
 
-  Image dst = Image(size, size, channels: src.channels, exif: src.exif,
-      iccp: src.iccProfile);
+  Image dst = Image(size, size,
+      channels: src.channels, exif: src.exif, iccp: src.iccProfile);
 
   double dy = src.height / height;
   double dx = src.width / width;

--- a/lib/src/transform/copy_rotate.dart
+++ b/lib/src/transform/copy_rotate.dart
@@ -16,9 +16,8 @@ Image copyRotate(Image src, num angle,
     int iangle = nangle ~/ 90.0;
     switch (iangle) {
       case 1: // 90 deg.
-        Image dst =
-            Image(src.height, src.width, channels: src.channels,
-                exif: src.exif, iccp: src.iccProfile);
+        Image dst = Image(src.height, src.width,
+            channels: src.channels, exif: src.exif, iccp: src.iccProfile);
         for (int y = 0; y < dst.height; ++y) {
           for (int x = 0; x < dst.width; ++x) {
             dst.setPixel(x, y, src.getPixel(y, hm1 - x));
@@ -26,9 +25,8 @@ Image copyRotate(Image src, num angle,
         }
         return dst;
       case 2: // 180 deg.
-        Image dst =
-            Image(src.width, src.height, channels: src.channels, exif: src.exif,
-                iccp: src.iccProfile);
+        Image dst = Image(src.width, src.height,
+            channels: src.channels, exif: src.exif, iccp: src.iccProfile);
         for (int y = 0; y < dst.height; ++y) {
           for (int x = 0; x < dst.width; ++x) {
             dst.setPixel(x, y, src.getPixel(wm1 - x, hm1 - y));
@@ -36,9 +34,8 @@ Image copyRotate(Image src, num angle,
         }
         return dst;
       case 3: // 270 deg.
-        Image dst =
-            Image(src.height, src.width, channels: src.channels, exif: src.exif,
-                iccp: src.iccProfile);
+        Image dst = Image(src.height, src.width,
+            channels: src.channels, exif: src.exif, iccp: src.iccProfile);
         for (int y = 0; y < dst.height; ++y) {
           for (int x = 0; x < dst.width; ++x) {
             dst.setPixel(x, y, src.getPixel(wm1 - y, x));

--- a/lib/src/transform/flip.dart
+++ b/lib/src/transform/flip.dart
@@ -3,8 +3,10 @@ import '../image.dart';
 enum Flip {
   /// Flip the image horizontally.
   horizontal,
+
   /// Flip the image vertically.
   vertical,
+
   /// Flip the image both horizontally and vertically.
   both
 }

--- a/lib/src/transform/trim.dart
+++ b/lib/src/transform/trim.dart
@@ -5,12 +5,16 @@ import '../transform/copy_into.dart';
 class Trim {
   /// Trim the image down from the top.
   static const top = Trim._internal(1);
+
   /// Trim the image up from the bottom.
   static const bottom = Trim._internal(2);
+
   /// Trim the left edge of the image.
   static const left = Trim._internal(4);
+
   /// Trim the right edge of the image.
   static const right = Trim._internal(8);
+
   /// Trim all edges of the image.
   static const all = Trim._internal(1 | 2 | 4 | 8);
 
@@ -24,9 +28,11 @@ class Trim {
 enum TrimMode {
   /// Trim an image to the top-left and bottom-right most non-transparent pixels
   transparent,
+
   /// Trim an image to the top-left and bottom-right most pixels that are not the
   /// same as the top-left most pixel of the image.
   topLeftColor,
+
   /// Trim an image to the top-left and bottom-right most pixels that are not the
   /// same as the bottom-right most pixel of the image.
   bottomRightColor
@@ -35,14 +41,14 @@ enum TrimMode {
 /// Find the crop area to be used by the trim function. Returns the
 /// coordinates as [x, y, width, height]. You could pass these coordinates
 /// to the [copyCrop] function to crop the image.
-List<int> findTrim(Image src, {TrimMode mode = TrimMode.transparent,
-                   Trim sides = Trim.all}) {
+List<int> findTrim(Image src,
+    {TrimMode mode = TrimMode.transparent, Trim sides = Trim.all}) {
   int h = src.height;
   int w = src.width;
 
-  int bg = (mode == TrimMode.topLeftColor) ? src.getPixel(0, 0)
-      : (mode == TrimMode.bottomRightColor) ? src.getPixel(w - 1, h - 1)
-      : 0;
+  int bg = (mode == TrimMode.topLeftColor)
+      ? src.getPixel(0, 0)
+      : (mode == TrimMode.bottomRightColor) ? src.getPixel(w - 1, h - 1) : 0;
 
   int xmin = w;
   int xmax = 0;
@@ -102,16 +108,16 @@ List<int> findTrim(Image src, {TrimMode mode = TrimMode.transparent,
 /// [sides] can be used to control which sides of the image get trimmed,
 /// and can be any combination of [Trim.top], [Trim.bottom], [Trim.left],
 /// and [Trim.right].
-Image trim(Image src, {TrimMode mode = TrimMode.transparent,
-           Trim sides = Trim.all}) {
+Image trim(Image src,
+    {TrimMode mode = TrimMode.transparent, Trim sides = Trim.all}) {
   if (mode == TrimMode.transparent && src.channels == Channels.rgb) {
     return new Image.from(src);
   }
 
   List<int> crop = findTrim(src, mode: mode, sides: sides);
 
-  Image dst = Image(crop[2], crop[3], channels: Channels.rgba, exif: src.exif,
-      iccp: src.iccProfile);
+  Image dst = Image(crop[2], crop[3],
+      channels: Channels.rgba, exif: src.exif, iccp: src.iccProfile);
 
   copyInto(dst, src,
       srcX: crop[0], srcY: crop[1], srcW: crop[2], srcH: crop[3], blend: false);

--- a/lib/src/util/input_buffer.dart
+++ b/lib/src/util/input_buffer.dart
@@ -12,8 +12,8 @@ class InputBuffer {
   bool bigEndian;
 
   /// Create a InputStream for reading from a List<int>
-  InputBuffer(List<int> buffer, {this.bigEndian = false, int offset = 0,
-              int length})
+  InputBuffer(List<int> buffer,
+      {this.bigEndian = false, int offset = 0, int length})
       : this.buffer = buffer,
         this.start = offset,
         this.offset = offset,
@@ -249,8 +249,7 @@ class InputBuffer {
   Uint32List toUint32List([int offset = 0]) {
     if (buffer is Uint8List) {
       Uint8List b = buffer as Uint8List;
-      return Uint32List.view(
-          b.buffer, b.offsetInBytes + this.offset + offset);
+      return Uint32List.view(b.buffer, b.offsetInBytes + this.offset + offset);
     }
     return Uint32List.view(toUint8List().buffer);
   }

--- a/lib/src/util/interpolation.dart
+++ b/lib/src/util/interpolation.dart
@@ -1,8 +1,3 @@
 // enum Interpolation
 
-enum Interpolation {
-  nearest,
-  linear,
-  cubic,
-  average
-}
+enum Interpolation { nearest, linear, cubic, average }

--- a/lib/src/util/point.dart
+++ b/lib/src/util/point.dart
@@ -1,4 +1,3 @@
-
 /// 2-dimensional point
 class Point {
   num x;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: image
-version: 2.1.4
+version: 2.1.5
 author: Brendan Duncan <brendanduncan@gmail.com>
 description: Provides server and web apps the ability to load, manipulate, and save images with various image file formats including PNG, JPEG, GIF, WebP, TIFF, TGA, PSD, PVR, and OpenEXR.
 homepage: https://github.com/brendan-duncan/image

--- a/test/color_test.dart
+++ b/test/color_test.dart
@@ -75,8 +75,8 @@ void main() {
       expect(argb[2], 128);
       expect(argb[3], 64);
 
-      var image_argb = Image.fromBytes(image.width, image.height, argb,
-                                      format: Format.argb);
+      var image_argb =
+          Image.fromBytes(image.width, image.height, argb, format: Format.argb);
       expect(getRed(image_argb[0]), 200);
       expect(getGreen(image_argb[0]), 128);
       expect(getBlue(image_argb[0]), 64);
@@ -88,8 +88,8 @@ void main() {
       expect(abgr[2], 128);
       expect(abgr[3], 200);
 
-      var image_abgr = Image.fromBytes(image.width, image.height, abgr,
-          format: Format.abgr);
+      var image_abgr =
+          Image.fromBytes(image.width, image.height, abgr, format: Format.abgr);
       expect(getRed(image_abgr[0]), 200);
       expect(getGreen(image_abgr[0]), 128);
       expect(getBlue(image_abgr[0]), 64);
@@ -101,8 +101,8 @@ void main() {
       expect(rgba[2], 64);
       expect(rgba[3], 255);
 
-      var image_rgba = Image.fromBytes(image.width, image.height, rgba,
-          format: Format.rgba);
+      var image_rgba =
+          Image.fromBytes(image.width, image.height, rgba, format: Format.rgba);
       expect(getRed(image_rgba[0]), 200);
       expect(getGreen(image_rgba[0]), 128);
       expect(getBlue(image_rgba[0]), 64);
@@ -114,8 +114,8 @@ void main() {
       expect(bgra[2], 200);
       expect(bgra[3], 255);
 
-      var image_bgra = Image.fromBytes(image.width, image.height, bgra,
-          format: Format.bgra);
+      var image_bgra =
+          Image.fromBytes(image.width, image.height, bgra, format: Format.bgra);
       expect(getRed(image_bgra[0]), 200);
       expect(getGreen(image_bgra[0]), 128);
       expect(getBlue(image_bgra[0]), 64);
@@ -126,8 +126,8 @@ void main() {
       expect(rgb[1], 128);
       expect(rgb[2], 64);
 
-      var image_rgb = Image.fromBytes(image.width, image.height, rgb,
-          format: Format.rgb);
+      var image_rgb =
+          Image.fromBytes(image.width, image.height, rgb, format: Format.rgb);
       expect(getRed(image_rgb[0]), 200);
       expect(getGreen(image_rgb[0]), 128);
       expect(getBlue(image_rgb[0]), 64);
@@ -138,8 +138,8 @@ void main() {
       expect(bgr[1], 128);
       expect(bgr[2], 200);
 
-      var image_bgr = Image.fromBytes(image.width, image.height, bgr,
-          format: Format.bgr);
+      var image_bgr =
+          Image.fromBytes(image.width, image.height, bgr, format: Format.bgr);
       expect(getRed(image_bgr[0]), 200);
       expect(getGreen(image_bgr[0]), 128);
       expect(getBlue(image_bgr[0]), 64);

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -4,9 +4,11 @@ import 'package:test/test.dart';
 
 void main() {
   group('filter', () {
-    var image = readJpg(new File('test/res/jpg/portrait_5.jpg').readAsBytesSync());
+    var image =
+        readJpg(new File('test/res/jpg/portrait_5.jpg').readAsBytesSync());
     image = copyResize(image, width: 400);
-    var image2 = readPng(new File('test/res/png/alpha_edge.png').readAsBytesSync());
+    var image2 =
+        readPng(new File('test/res/png/alpha_edge.png').readAsBytesSync());
 
     test('fill', () {
       Image f = Image(10, 10, channels: Channels.rgb);
@@ -50,8 +52,8 @@ void main() {
 
     test('copyInto', () {
       Image s = Image.from(image);
-      Image d = Image(image.width + 20, image.height + 20,
-          channels: image.channels);
+      Image d =
+          Image(image.width + 20, image.height + 20, channels: image.channels);
       fill(d, 0xff0000ff);
       copyInto(d, s, dstX: 10, dstY: 10);
       copyInto(d, image2, dstX: 10, dstY: 10);
@@ -312,8 +314,8 @@ void main() {
     test('remapColors', () {
       Image f = Image.from(image);
       f.channels = Channels.rgba;
-      remapColors(f, red: Channel.green, green: Channel.red,
-          alpha: Channel.luminance);
+      remapColors(f,
+          red: Channel.green, green: Channel.red, alpha: Channel.luminance);
 
       File fp = File('out/remapColors.jpg');
       fp.createSync(recursive: true);

--- a/test/font_test.dart
+++ b/test/font_test.dart
@@ -20,8 +20,7 @@ void main() {
     });
 
     test('zip/text', () {
-      List<int> fontZip =
-          File('test/res/font/test_text.zip').readAsBytesSync();
+      List<int> fontZip = File('test/res/font/test_text.zip').readAsBytesSync();
       BitmapFont font = readFontZip(fontZip);
 
       var img = copyResize(image, width: 400);

--- a/test/gif_test.dart
+++ b/test/gif_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:image/image.dart';
 import 'package:test/test.dart';
 
@@ -6,79 +7,83 @@ void main() {
   Directory dir = Directory('test/res/gif');
   var files = dir.listSync();
 
-  group('Gif/getInfo', () {
-    for (var f in files) {
-      if (f is! File || !f.path.endsWith('.gif')) {
-        continue;
-      }
-
-      String name = f.path.split(new RegExp(r'(/|\\)')).last;
-      test('$name', () {
-        var bytes = (f as File).readAsBytesSync();
-
-        GifInfo data = GifDecoder().startDecode(bytes);
-        if (data == null) {
-          throw new ImageException('Unable to parse Gif info: $name.');
+  group('Gif', () {
+    test('getInfo', () {
+      for (var f in files) {
+        if (f is! File || !f.path.endsWith('.gif')) {
+          continue;
         }
-      });
-    }
-  });
 
-  group('Gif/decodeImage', () {
-    for (var f in files) {
-      if (f is! File || !f.path.endsWith('.gif')) {
-        continue;
+        String name = f.path.split(RegExp(r'(/|\\)')).last;
+        test('$name', () {
+          var bytes = (f as File).readAsBytesSync();
+
+          GifInfo data = GifDecoder().startDecode(bytes);
+          if (data == null) {
+            throw ImageException('Unable to parse Gif info: $name.');
+          }
+        });
+      }
+    });
+
+    test('decodeImage', () {
+      for (var f in files) {
+        if (f is! File || !f.path.endsWith('.gif')) {
+          continue;
+        }
+
+        String name = f.path.split(RegExp(r'(/|\\)')).last;
+        test('$name', () {
+          var bytes = (f as File).readAsBytesSync();
+          Image image = GifDecoder().decodeImage(bytes);
+          File('out/gif/$name.png')
+            ..createSync(recursive: true)
+            ..writeAsBytesSync(encodePng(image));
+        });
+      }
+    });
+
+    test('decodeAnimation', () {
+      for (var f in files) {
+        if (f is! File || !f.path.endsWith('cars.gif')) {
+          continue;
+        }
+
+        String name = f.path.split(RegExp(r'(/|\\)')).last;
+        test('$name', () {
+          List<int> bytes = (f as File).readAsBytesSync();
+          Animation anim = GifDecoder().decodeAnimation(bytes);
+          expect(anim.length, equals(30));
+          expect(anim.loopCount, equals(0));
+        });
+      }
+    });
+
+    test('encodeAnimation', () {
+      Animation anim = Animation();
+      anim.loopCount = 10;
+
+      for (var i = 0; i < 10; i++) {
+        Image image = Image(480, 120);
+        drawString(image, arial_48, 100, 60, i.toString());
+        anim.addFrame(image);
       }
 
-      String name = f.path.split(new RegExp(r'(/|\\)')).last;
-      test('$name', () {
-        var bytes = (f as File).readAsBytesSync();
-        Image image = GifDecoder().decodeImage(bytes);
-        new File('out/gif/$name.png')
-          ..createSync(recursive: true)
-          ..writeAsBytesSync(encodePng(image));
-      });
-    }
-  });
+      List<int> gif = encodeGifAnimation(anim, samplingFactor: 480);
 
-  group('Gif/decodeAnimation', () {
-    for (var f in files) {
-      if (f is! File || !f.path.endsWith('cars.gif')) {
-        continue;
-      }
+      File('out/gif/encodeAnimation.gif')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(gif);
+    });
 
-      String name = f.path.split(new RegExp(r'(/|\\)')).last;
-      test('$name', () {
-        List<int> bytes = (f as File).readAsBytesSync();
-        Animation anim = GifDecoder().decodeAnimation(bytes);
-        expect(anim.length, equals(30));
-        expect(anim.loopCount, equals(0));
-      });
-    }
-  });
+    test('encodeImage', () {
+      List<int> bytes = File('test/res/jpg/jpeg444.jpg').readAsBytesSync();
+      Image image = JpegDecoder().decodeImage(bytes);
 
-  group('Gif/encodeAnimation', () {
-    Animation anim = Animation();
-    anim.loopCount = 10;
-    for (var i = 0; i < 10; i++) {
-      Image image = Image(480, 120);
-      drawString(image, arial_48, 100, 60, i.toString());
-      anim.addFrame(image);
-    }
-
-    List<int> gif = encodeGifAnimation(anim);
-    new File('out/gif/encodeAnimation.gif')
-      ..createSync(recursive: true)
-      ..writeAsBytesSync(gif);
-  });
-
-  group('Gif/encodeImage', () {
-    List<int> bytes = File('test/res/jpg/jpeg444.jpg').readAsBytesSync();
-    Image image = JpegDecoder().decodeImage(bytes);
-
-    List<int> gif = GifEncoder().encodeImage(image);
-    new File('out/gif/jpeg444.gif')
-      ..createSync(recursive: true)
-      ..writeAsBytesSync(gif);
+      List<int> gif = GifEncoder().encodeImage(image);
+      File('out/gif/jpeg444.gif')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(gif);
+    });
   });
 }

--- a/test/gif_test.dart
+++ b/test/gif_test.dart
@@ -8,56 +8,50 @@ void main() {
   var files = dir.listSync();
 
   group('Gif', () {
-    test('getInfo', () {
-      for (var f in files) {
-        if (f is! File || !f.path.endsWith('.gif')) {
-          continue;
-        }
-
-        String name = f.path.split(RegExp(r'(/|\\)')).last;
-        test('$name', () {
-          var bytes = (f as File).readAsBytesSync();
-
-          GifInfo data = GifDecoder().startDecode(bytes);
-          if (data == null) {
-            throw ImageException('Unable to parse Gif info: $name.');
-          }
-        });
+    for (var f in files) {
+      if (f is! File || !f.path.endsWith('.gif')) {
+        continue;
       }
-    });
 
-    test('decodeImage', () {
-      for (var f in files) {
-        if (f is! File || !f.path.endsWith('.gif')) {
-          continue;
+      String name = f.path.split(RegExp(r'(/|\\)')).last;
+      test('getInfo $name', () {
+        var bytes = (f as File).readAsBytesSync();
+
+        GifInfo data = GifDecoder().startDecode(bytes);
+        if (data == null) {
+          throw ImageException('Unable to parse Gif info: $name.');
         }
+      });
+    }
 
-        String name = f.path.split(RegExp(r'(/|\\)')).last;
-        test('$name', () {
-          var bytes = (f as File).readAsBytesSync();
-          Image image = GifDecoder().decodeImage(bytes);
-          File('out/gif/$name.png')
-            ..createSync(recursive: true)
-            ..writeAsBytesSync(encodePng(image));
-        });
+    for (var f in files) {
+      if (f is! File || !f.path.endsWith('.gif')) {
+        continue;
       }
-    });
 
-    test('decodeAnimation', () {
-      for (var f in files) {
-        if (f is! File || !f.path.endsWith('cars.gif')) {
-          continue;
-        }
+      String name = f.path.split(RegExp(r'(/|\\)')).last;
+      test('decodeImage $name', () {
+        var bytes = (f as File).readAsBytesSync();
+        Image image = GifDecoder().decodeImage(bytes);
+        File('out/gif/$name.png')
+          ..createSync(recursive: true)
+          ..writeAsBytesSync(encodePng(image));
+      });
+    }
 
-        String name = f.path.split(RegExp(r'(/|\\)')).last;
-        test('$name', () {
-          List<int> bytes = (f as File).readAsBytesSync();
-          Animation anim = GifDecoder().decodeAnimation(bytes);
-          expect(anim.length, equals(30));
-          expect(anim.loopCount, equals(0));
-        });
+    for (var f in files) {
+      if (f is! File || !f.path.endsWith('cars.gif')) {
+        continue;
       }
-    });
+
+      String name = f.path.split(RegExp(r'(/|\\)')).last;
+      test('decodeAnimation $name', () {
+        List<int> bytes = (f as File).readAsBytesSync();
+        Animation anim = GifDecoder().decodeAnimation(bytes);
+        expect(anim.length, equals(30));
+        expect(anim.loopCount, equals(0));
+      });
+    }
 
     test('encodeAnimation', () {
       Animation anim = Animation();

--- a/test/pvrtc_test.dart
+++ b/test/pvrtc_test.dart
@@ -28,8 +28,7 @@ void main() {
     });
 
     test('encode_rgba_4bpp', () {
-      List<int> bytes =
-          File('test/res/png/alpha_edge.png').readAsBytesSync();
+      List<int> bytes = File('test/res/png/alpha_edge.png').readAsBytesSync();
       Image image = PngDecoder().decodeImage(bytes);
 
       new File('out/pvrtc/alpha_before.png')

--- a/test/webp_test.dart
+++ b/test/webp_test.dart
@@ -37,7 +37,6 @@ void main() {
     }
   });
 
-
   group('WebP/decodeImage', () {
     test('validate', () {
       File file = File('test/res/webp/2b.webp');

--- a/web/filter_lab.dart
+++ b/web/filter_lab.dart
@@ -6,8 +6,8 @@ CanvasElement canvas;
 DivElement logDiv;
 Image origImage;
 
-void _addControl(String label, String value, DivElement parent,
-                 dynamic callback) {
+void _addControl(
+    String label, String value, DivElement parent, dynamic callback) {
   LabelElement amountLabel = LabelElement();
   amountLabel.text = label + ':';
   var amountEdit = InputElement();
@@ -148,8 +148,8 @@ void testVignette() {
     image = vignette(image, start: start, end: end, amount: amount);
 
     // Fill the buffer with our image data.
-    filterImageData.data.setRange(0, filterImageData.data.length,
-        image.getBytes());
+    filterImageData.data
+        .setRange(0, filterImageData.data.length, image.getBytes());
     // Draw the buffer onto the canvas.
     canvas.context2D.clearRect(0, 0, canvas.width, canvas.height);
     canvas.context2D.putImageData(filterImageData, 0, 0);
@@ -192,8 +192,8 @@ void testPixelate() {
     image = pixelate(image, blockSize);
 
     // Fill the buffer with our image data.
-    filterImageData.data.setRange(0, filterImageData.data.length,
-        image.getBytes());
+    filterImageData.data
+        .setRange(0, filterImageData.data.length, image.getBytes());
     // Draw the buffer onto the canvas.
     canvas.context2D.clearRect(0, 0, canvas.width, canvas.height);
     canvas.context2D.putImageData(filterImageData, 0, 0);
@@ -226,12 +226,12 @@ void testColorOffset() {
     Stopwatch t = Stopwatch();
     t.start();
     Image image = Image.from(origImage);
-    image = colorOffset(image, red: red, green: green, blue: blue,
-        alpha: alpha);
+    image =
+        colorOffset(image, red: red, green: green, blue: blue, alpha: alpha);
 
     // Fill the buffer with our image data.
-    filterImageData.data.setRange(0, filterImageData.data.length,
-        image.getBytes());
+    filterImageData.data
+        .setRange(0, filterImageData.data.length, image.getBytes());
     // Draw the buffer onto the canvas.
     canvas.context2D.clearRect(0, 0, canvas.width, canvas.height);
     canvas.context2D.putImageData(filterImageData, 0, 0);

--- a/web/test_formats.dart
+++ b/web/test_formats.dart
@@ -73,7 +73,8 @@ void main() {
           // Create a buffer that the canvas can draw.
           ImageData d = c.context2D.createImageData(c.width, c.height);
           // Fill the buffer with our image data.
-          d.data.setRange(0, d.data.length, newImage.getBytes(format: Format.rgba));
+          d.data.setRange(
+              0, d.data.length, newImage.getBytes(format: Format.rgba));
           // Draw the buffer onto the canvas.
           c.context2D.putImageData(d, 0, 0);
 
@@ -98,7 +99,8 @@ void main() {
           }
 
           // Fill the buffer with our image data.
-          d.data.setRange(0, d.data.length, image.getBytes(format: Format.rgba));
+          d.data
+              .setRange(0, d.data.length, image.getBytes(format: Format.rgba));
           // Draw the buffer onto the canvas.
           c.context2D.putImageData(d, 0, 0);
         });

--- a/web/test_jpeg_encoder.dart
+++ b/web/test_jpeg_encoder.dart
@@ -13,8 +13,8 @@ void main() {
   ctx.drawImage(theImg, 0, 0);
 
   var bytes = ctx.getImageData(0, 0, cvs.width, cvs.height).data;
-  Image image = Image.fromBytes(cvs.width, cvs.height, bytes,
-                                format: Format.rgba);
+  Image image =
+      Image.fromBytes(cvs.width, cvs.height, bytes, format: Format.rgba);
 
   var jpg = encodeJpg(image, quality: 25);
 


### PR DESCRIPTION
GIF encoding time for simple `500x500` animations with a few dozens of frames takes close to half an hour for me. Either your implementation of NeuQuant is faulty or color quantization is simply unnecessary. A quick fix for now is introducing `samplingFactor`.

Fixes #129 

I also ran `dartfmt` in the project, hence, the many changes.