### PR TITLE
Properly use `test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+- Updated some tests to use `test`-syntax.
+
 ## 2.1.4 - June 01, 2019
 
 - Optimize fillRect, drawPixel, and other drawing functions when opaque colors are used.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: image
-version: 2.1.4
+version: 2.1.5
 author: Brendan Duncan <brendanduncan@gmail.com>
 description: Provides server and web apps the ability to load, manipulate, and save images with various image file formats including PNG, JPEG, GIF, WebP, TIFF, TGA, PSD, PVR, and OpenEXR.
 homepage: https://github.com/brendan-duncan/image

--- a/test/exr_test.dart
+++ b/test/exr_test.dart
@@ -1,15 +1,20 @@
 import 'dart:io';
 import 'package:image/image.dart';
+import 'package:test/test.dart';
 
 void main() {
-  List<int> bytes = File('test/res/exr/grid.exr').readAsBytesSync();
+  group('EXR', () {
+    test('decoding', () {
+      List<int> bytes = File('test/res/exr/grid.exr').readAsBytesSync();
 
-  ExrDecoder dec = ExrDecoder();
-  dec.startDecode(bytes);
-  Image img = dec.decodeFrame(0);
+      ExrDecoder dec = ExrDecoder();
+      dec.startDecode(bytes);
+      Image img = dec.decodeFrame(0);
 
-  List<int> png = PngEncoder().encodeImage(img);
-  new File('out/exr/grid.png')
-    ..createSync(recursive: true)
-    ..writeAsBytesSync(png);
+      List<int> png = PngEncoder().encodeImage(img);
+      File('out/exr/grid.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(png);
+    });
+  });
 }

--- a/test/gif_test.dart
+++ b/test/gif_test.dart
@@ -6,79 +6,75 @@ void main() {
   Directory dir = Directory('test/res/gif');
   var files = dir.listSync();
 
-  group('Gif/getInfo', () {
+  group('GIF', () {
     for (var f in files) {
       if (f is! File || !f.path.endsWith('.gif')) {
         continue;
       }
 
-      String name = f.path.split(new RegExp(r'(/|\\)')).last;
-      test('$name', () {
+      String name = f.path.split(RegExp(r'(/|\\)')).last;
+      test('getInfo $name', () {
         var bytes = (f as File).readAsBytesSync();
 
         GifInfo data = GifDecoder().startDecode(bytes);
         if (data == null) {
-          throw new ImageException('Unable to parse Gif info: $name.');
+          throw ImageException('Unable to parse Gif info: $name.');
         }
       });
     }
-  });
 
-  group('Gif/decodeImage', () {
     for (var f in files) {
       if (f is! File || !f.path.endsWith('.gif')) {
         continue;
       }
 
-      String name = f.path.split(new RegExp(r'(/|\\)')).last;
-      test('$name', () {
+      String name = f.path.split(RegExp(r'(/|\\)')).last;
+      test('decodeImage $name', () {
         var bytes = (f as File).readAsBytesSync();
         Image image = GifDecoder().decodeImage(bytes);
-        new File('out/gif/$name.png')
+        File('out/gif/$name.png')
           ..createSync(recursive: true)
           ..writeAsBytesSync(encodePng(image));
       });
     }
-  });
 
-  group('Gif/decodeAnimation', () {
     for (var f in files) {
       if (f is! File || !f.path.endsWith('cars.gif')) {
         continue;
       }
 
-      String name = f.path.split(new RegExp(r'(/|\\)')).last;
-      test('$name', () {
+      String name = f.path.split(RegExp(r'(/|\\)')).last;
+      test('decodeAnimation $name', () {
         List<int> bytes = (f as File).readAsBytesSync();
         Animation anim = GifDecoder().decodeAnimation(bytes);
         expect(anim.length, equals(30));
         expect(anim.loopCount, equals(0));
       });
     }
-  });
 
-  group('Gif/encodeAnimation', () {
-    Animation anim = Animation();
-    anim.loopCount = 10;
-    for (var i = 0; i < 10; i++) {
-      Image image = Image(480, 120);
-      drawString(image, arial_48, 100, 60, i.toString());
-      anim.addFrame(image);
-    }
+    test('encodeAnimation', () {
+      Animation anim = Animation();
+      anim.loopCount = 10;
+      for (var i = 0; i < 10; i++) {
+        Image image = Image(480, 120);
+        drawString(image, arial_48, 100, 60, i.toString());
+        anim.addFrame(image);
+      }
 
-    List<int> gif = encodeGifAnimation(anim);
-    new File('out/gif/encodeAnimation.gif')
-      ..createSync(recursive: true)
-      ..writeAsBytesSync(gif);
-  });
+      List<int> gif = encodeGifAnimation(anim);
+      File('out/gif/encodeAnimation.gif')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(gif);
+    });
 
-  group('Gif/encodeImage', () {
-    List<int> bytes = File('test/res/jpg/jpeg444.jpg').readAsBytesSync();
-    Image image = JpegDecoder().decodeImage(bytes);
+    test('encodeImage', () {
+      List<int> bytes = File('test/res/jpg/jpeg444.jpg').readAsBytesSync();
+      Image image = JpegDecoder().decodeImage(bytes);
 
-    List<int> gif = GifEncoder().encodeImage(image);
-    new File('out/gif/jpeg444.gif')
-      ..createSync(recursive: true)
-      ..writeAsBytesSync(gif);
+      List<int> gif = GifEncoder().encodeImage(image);
+      File('out/gif/jpeg444.gif')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(gif);
+    });
   });
 }


### PR DESCRIPTION
Some of the tests did not properly call `test` when testing.

Regarding the changelog entry, this is supposed to be merged together with #155 and #156 if these are merged, i.e. the changes can all be published together as version `2.1.5` to Pub.  
Furthermore, this pull request already fixes the warnings addressed in #156 for the test files. If #156 is merged, I think that this should be merged afterwards, i.e. merge order could be #155 -> #156 -> #157 resolving merge conflicts on the way.