### PR TITLE
Bugfix on newline char

### DIFF
--- a/lib/src/bitmap_font.dart
+++ b/lib/src/bitmap_font.dart
@@ -278,7 +278,11 @@ class BitmapFont {
     List<XmlAttribute> charsAttrs;
     List<XmlAttribute> kerningsAttrs;
 
-    List<String> lines = content.split('\n');
+    List<String> lines = [];
+    lines = content.split('\r\n');
+    if(lines.length <= 1) {
+      lines = content.split('\n');
+    }
 
     for (String line in lines) {
       if (line.isEmpty) {


### PR DESCRIPTION
If the fnt file uses \r\n for new line the package does not work properly and is unable to load a passed BitmapFont.
I used a tool called Hiero to create the zip BitmapFont file. It uses \r\n as chars of new line. I got the error "Cannot find png map file" since it was not able to split correctly the zipped fnt file. With this bugfix I'm able to import also the fnt file with \r\n.