### PR TITLE
duration is now in ms

### DIFF
--- a/lib/src/formats/png_encoder.dart
+++ b/lib/src/formats/png_encoder.dart
@@ -134,7 +134,7 @@ class PngEncoder extends Encoder {
     chunk.writeUint32(xOffset);
     chunk.writeUint32(yOffset);
     chunk.writeUint16(delay);
-    chunk.writeUint16(0); // delay denominator
+    chunk.writeUint16(1000); // delay denominator
     chunk.writeByte(disposeMethod.index);
     chunk.writeByte(blendMethod.index);
     _writeChunk(output, 'fcTL', chunk.getBytes());


### PR DESCRIPTION
From the mozilla APNG specs (https://wiki.mozilla.org/APNG_Specification):

> `The `delay_num` and `delay_den` parameters together specify a fraction indicating the time to display the current frame, in seconds. If the denominator is 0, it is to be treated as if it were 100 (that is, `delay_num` then specifies 1/100ths of a second).`

Since we currently have '0' as delay_den, it means that the 'delay' parameter will be multiplied by 1/100 seconds. The problem is that the duration in an image (https://pub.dev/documentation/image/latest/image/Image/duration.html) is defined in milliseconds, and this parameter is used ad the delay in the png encode, which results in the output frame being 10 times slower than it should.

Sorry this is my first pull request on github, let me know if you need more informations. 