### PR TITLE
Fix EXIF loading fpr JPEG

### DIFF
--- a/lib/src/formats/jpeg/jpeg_data.dart
+++ b/lib/src/formats/jpeg/jpeg_data.dart
@@ -269,14 +269,14 @@ class JpegData {
     return c;
   }
 
-  num _readExifValue(InputBuffer block, int format, int offset) {
+  dynamic _readExifValue(InputBuffer block, int format, int offset) {
     const FMT_BYTE = 1;
-    //const FMT_STRING = 2;
+    const FMT_ASCII = 2;
     const FMT_USHORT = 3;
     const FMT_ULONG = 4;
     const FMT_URATIONAL = 5;
     const FMT_SBYTE = 6;
-    //const FMT_UNDEFINED = 7;
+    const FMT_UNDEFINED = 7;
     const FMT_SSHORT = 8;
     const FMT_SLONG = 9;
     const FMT_SRATIONAL = 10;
@@ -289,7 +289,10 @@ class JpegData {
         case FMT_SBYTE:
           return block.readInt8();
         case FMT_BYTE:
+        case FMT_UNDEFINED:
           return block.readByte();
+        case FMT_ASCII:
+          return block.readString(1);
         case FMT_USHORT:
           return block.readUint16();
         case FMT_ULONG:

--- a/lib/src/formats/jpeg/jpeg_data.dart
+++ b/lib/src/formats/jpeg/jpeg_data.dart
@@ -269,7 +269,7 @@ class JpegData {
     return c;
   }
 
-  num _readExifValue(InputBuffer block, int format) {
+  num _readExifValue(InputBuffer block, int format, int offset) {
     const FMT_BYTE = 1;
     //const FMT_STRING = 2;
     const FMT_USHORT = 3;
@@ -283,36 +283,45 @@ class JpegData {
     const FMT_SINGLE = 11;
     const FMT_DOUBLE = 12;
 
-    switch (format) {
-      case FMT_SBYTE:
-        return block.readInt8();
-      case FMT_BYTE:
-        return block.readByte();
-      case FMT_USHORT:
-        return block.readUint16();
-      case FMT_ULONG:
-        return block.readUint32();
-      case FMT_URATIONAL:
-      case FMT_SRATIONAL:
-        {
-          var num = block.readInt32();
-          var den = block.readInt32();
-          if (den == 0) {
-            return 0.0;
+    int initialBlockLength = block.length;
+    try {
+      switch (format) {
+        case FMT_SBYTE:
+          return block.readInt8();
+        case FMT_BYTE:
+          return block.readByte();
+        case FMT_USHORT:
+          return block.readUint16();
+        case FMT_ULONG:
+          return block.readUint32();
+        case FMT_URATIONAL:
+        case FMT_SRATIONAL:
+          {
+            InputBuffer buffer = block.peekBytes(8, offset);
+            var num = buffer.readInt32();
+            var den = buffer.readInt32();
+            if (den == 0) {
+              return 0.0;
+            }
+            return num / den;
           }
-          return num / den;
-        }
-      case FMT_SSHORT:
-        return block.readInt16();
-      case FMT_SLONG:
-        return block.readInt32();
+        case FMT_SSHORT:
+          return block.readInt16();
+        case FMT_SLONG:
+          return block.readInt32();
       // Not sure if this is correct (never seen float used in Exif format)
-      case FMT_SINGLE:
-        return block.readFloat32();
-      case FMT_DOUBLE:
-        return block.readFloat64();
-      default:
-        return 0;
+        case FMT_SINGLE:
+          return block.readFloat32();
+        case FMT_DOUBLE:
+          return block.peekBytes(8, offset).readFloat64();
+        default:
+          return 0;
+      }
+    } finally {
+      int bytesRead = initialBlockLength - block.length;
+      if (bytesRead < 4) {
+        block.skip(4 - bytesRead);
+      }
     }
   }
 
@@ -345,9 +354,11 @@ class JpegData {
 
       var byteCount = bytesPerFormat[format];
 
+      var offset = 0;
+
       // If its bigger than 4 bytes, the dir entry contains an offset.
       if (byteCount > 4) {
-        var offset = block.readUint32();
+        offset = block.readUint32();
         if (offset + byteCount > block.length) {
           continue; // Bogus pointer offset and / or bytecount value
         }
@@ -355,20 +366,7 @@ class JpegData {
         //ValuePtr = OffsetBase+OffsetVal;
       }
 
-      switch (tag) {
-        case TAG_ORIENTATION:
-          {
-            var orientation = _readExifValue(block, format);
-            exif.orientation = orientation.toInt();
-          }
-          break;
-        case TAG_EXIF_OFFSET:
-        case TAG_INTEROP_OFFSET:
-          break;
-        default:
-          // skip unknown tags
-          break;
-      }
+      exif.data[tag] = _readExifValue(block, format, offset);
     }
   }
 


### PR DESCRIPTION
Ensure that all tags are loaded (why skip unknown tags?), and that the 4 value offset bytes of the previous tag are skipped once we attempt to read the next tag.

Addresses issue #132  .