### PR TITLE
Fixed GIF Disposal Method parsing

### DIFF
--- a/lib/src/formats/gif_decoder.dart
+++ b/lib/src/formats/gif_decoder.dart
@@ -102,7 +102,7 @@ class GifDecoder extends Decoder {
     var duration = _input.readUint16();
     var transparent = _input.readByte();
     /*int endBlock =*/ _input.readByte();
-    var disposalMethod = (b >> 3) & 0x7;
+    var disposalMethod = (b >> 2) & 0x7;
     //int userInput = (b >> 1) & 0x1;
     var transparentFlag = b & 0x1;
 


### PR DESCRIPTION
There is a small mistake in the Gif parsing function.

From the [GIF89a RFC (section 23.c)](https://www.w3.org/Graphics/GIF/spec-gif89a.txt):
```
      <Packed Fields>  =     Reserved                      3 Bits
                             Disposal Method               3 Bits
                             User Input Flag               1 Bit
                             Transparent Color Flag        1 Bit
```

The Disposal Method field is only two bits from the end, so it should only be right shifted by 2 instead 3 to be parsed.