### PR TITLE
Update xml dependency to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.14 - June 14, 2020
+
+- Update xml dependency to 4.2.0
+
 ## 2.1.13 - May 21, 2020
 
 - Improvements for JPEG EXIF decoding

--- a/lib/src/bitmap_font.dart
+++ b/lib/src/bitmap_font.dart
@@ -48,7 +48,7 @@ class BitmapFont {
     fnt = fnt.trimLeft();
 
     if (fnt.startsWith('<?xml') || fnt.startsWith('<font>')) {
-      doc = parse(fnt);
+      doc = XmlDocument.parse(fnt);
       if (doc == null) {
         throw ImageException('Invalid font XML');
       }
@@ -83,7 +83,7 @@ class BitmapFont {
 
     /// Added <?xml which may be present, appropriately
     if (font_str.startsWith('<?xml') || font_str.startsWith('<font>')) {
-      xml = parse(font_str);
+      xml = XmlDocument.parse(font_str);
       if (xml == null) {
         throw ImageException('Invalid font XML');
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
   archive: '>=1.0.16 <3.0.0'
-  xml: '>=3.2.5 <4.0.0'
+  xml: '>=4.2.0 <5.0.0'
 dev_dependencies:
   test: '>=0.12.42 <2.0.0'
   pedantic: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: image
-version: 2.1.13
+version: 2.1.14
 description: Provides server and web apps the ability to load, manipulate, and save images with various image file formats including PNG, JPEG, GIF, BMP, WebP, TIFF, TGA, PSD, PVR, and OpenEXR.
 homepage: https://github.com/brendan-duncan/image
 documentation: https://github.com/brendan-duncan/image/wiki


### PR DESCRIPTION
This pr updates the xml package to version 4.2.0 and replaces now deprecated functions with their replacements.

This upgrade is needed to fix compatibility issues with packages like flutter_svg that rely on xml 4.x.x

Fixes #218