### PR TITLE
BugFix: 3 channel source image was not being converted properly.

### DIFF
--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -613,7 +613,7 @@ class Image {
         }
         break;
       case Format.bgr:
-        for (var i = 0, j = 0, len = input.length; i < len; i += 4, j += 3) {
+        for (var i = 0, j = 0, len = input.length; j < len; i += 4, j += 3) {
           rgba[i + 0] = input[j + 2];
           rgba[i + 1] = input[j + 1];
           rgba[i + 2] = input[j + 0];
@@ -621,7 +621,7 @@ class Image {
         }
         break;
       case Format.rgb:
-        for (var i = 0, j = 0, len = input.length; i < len; i += 4, j += 3) {
+        for (var i = 0, j = 0, len = input.length; j < len; i += 4, j += 3) {
           rgba[i + 0] = input[j + 0];
           rgba[i + 1] = input[j + 1];
           rgba[i + 2] = input[j + 2];
@@ -629,7 +629,7 @@ class Image {
         }
         break;
       case Format.luminance:
-        for (var i = 0, j = 0, len = input.length; i < len; i += 4, ++j) {
+        for (var i = 0, j = 0, len = input.length; j < len; i += 4, ++j) {
           rgba[i + 0] = input[j];
           rgba[i + 1] = input[j];
           rgba[i + 2] = input[j];


### PR DESCRIPTION
The loop in the original code does not run for the entirety of the 3 channel but stops short when the rgba buffer reaches the same length as the original image buffer. As the rgba buffer has 4 channels as compared to the 3 channels of the source image this causes black bars to appear at the bottom of the converted image. The loop should be run instead for the entirety of the length of the source image buffer, referenced by "j". 

