### PR TITLE
fix: jpeg validation throws exception when input png image

### DIFF
--- a/lib/src/formats/jpeg/jpeg_data.dart
+++ b/lib/src/formats/jpeg/jpeg_data.dart
@@ -49,6 +49,8 @@ class JpegData {
         // return success only when SOF and SOS have already found (as a jpeg without EOF.)
         break;
       }
+      input.offset += sectionByteSize - 2;
+      
       switch (marker) {
         case Jpeg.M_SOF0: // SOF0 (Start of Frame, Baseline DCT)
         case Jpeg.M_SOF1: // SOF1 (Start of Frame, Extended DCT)

--- a/lib/src/formats/jpeg/jpeg_data.dart
+++ b/lib/src/formats/jpeg/jpeg_data.dart
@@ -46,7 +46,8 @@ class JpegData {
       final sectionByteSize = input.readUint16();
       if (sectionByteSize < 2) {
         // jpeg section consists of more than 2 bytes at least
-        return false;
+        // return success only when SOF and SOS have already found (as a jpeg without EOF.)
+        break;
       }
       switch (marker) {
         case Jpeg.M_SOF0: // SOF0 (Start of Frame, Baseline DCT)


### PR DESCRIPTION
## What happens

`JpegData.validate`  method throws [`ImageException('Invalid Block')`](https://github.com/brendan-duncan/image/blob/bc2b7973804fa7878d3dacf8c9280106f05f5a85/lib/src/formats/jpeg/jpeg_data.dart#L236).

Validate method should finish successfully even if unexpected format found.

## How fixed

before
- Throw an exception when an unexpected image format found.

after
- when unexpected image format found, stop reading marker, and return whether jpeg flags (`SOF` and `SOF`) have found.

## How to Reproduce

A few pictures encounter this bug, another picture has no problem. Here is a process that can encounter this bug.

1. A Jpeg picture (Sorry for not able to upload because of personal information of our service. )
2. Load the picture with `NetworkImage`, and convert to `ImageInfo` by [this method](https://github.com/niwatly/flutter_app_components/blob/f7782decc81d5a431fc36baa5a549a1875b14238/lib/utility/extension.dart#L107-L132).
3. extract `ui.Image` in the `ImageInfo`, and generate `ByteData` with [`toByteData`](https://api.flutter.dev/flutter/dart-ui/Image/toByteData.html) method. first argument is `ImageByteFormat.png`.
4. `ByteBuffer` in the `ByteData` has an Uint8List. Get it with calling `asUnit8List` method.
6. input the int type list to the [`findDecorderFordata`](https://github.com/brendan-duncan/image/blob/bc2b7973804fa7878d3dacf8c9280106f05f5a85/lib/src/formats/formats.dart#L25-L77).
7. [`JpegData.validate`](https://github.com/brendan-duncan/image/blob/bc2b7973804fa7878d3dacf8c9280106f05f5a85/lib/src/formats/jpeg/jpeg_data.dart#L32-L62) methods throws ImageException.

In this case, the `length` parameter in the `_skipBlock` method is 0.

## Related Issues

- https://github.com/brendan-duncan/image/issues/230

