### PR TITLE
Copy exif data instead of removing

### DIFF
--- a/lib/src/transform/bake_orientation.dart
+++ b/lib/src/transform/bake_orientation.dart
@@ -13,8 +13,14 @@ Image bakeOrientation(Image image) {
     return bakedImage;
   }
 
-  // Clear the exif data.
-  bakedImage.exif.data.remove(ExifData.ORIENTATION);
+  // Copy all exif data except for orientation
+  bakedImage.exif = ExifData();
+  for (var key in image.exif.data.keys) {
+    if (key != ExifData.ORIENTATION) {
+      bakedImage.exif.data[key] = image.exif.data[key];
+    }
+  }
+
   switch (image.exif.orientation) {
     case 2:
       return flipHorizontal(bakedImage);


### PR DESCRIPTION
The bakeOrientation was not working correctly. The images were always rotated landscape in all photo viewers on all devices I tested. When reading exif data through image.exif.data, no rotation was present, but it clearly was somewhere. The remove function was not completely removing the orientation. I assume it also needs to be removed from rawData.

This commit copies all exif data other than orientation into the new image instead of removing orientation data from existing exif data. For some reason, this fixes the issue. It also retains all other exif data.

EDIT: I've looked into this further and this isn't the ideal solution. Raw exif data won't be retained. However, this is still better than completely breaking the BakeOrientation function. I'd rather have proper rotation and not preserve exif than preserve exif and have the wrong rotation.

I will look into properly parsing rawData and correctly removing the tag. It's quite a tricky task since there are no dart plugins that enable you to modify exif data. I'd have to write that myself...