### PR TITLE
Change boundary condition to prevent corrupting 1/4 of image

### DIFF
--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -204,7 +204,7 @@ class Image {
         return bytes;
       case Format.rgb:
         var bytes = Uint8List(width * height * 3);
-        for (var i = 0, j = 0, len = bytes.length; i < len; i += 4, j += 3) {
+        for (var i = 0, j = 0, len = bytes.length; j < len; i += 4, j += 3) {
           bytes[j + 0] = rgba[i + 0];
           bytes[j + 1] = rgba[i + 1];
           bytes[j + 2] = rgba[i + 2];
@@ -212,7 +212,7 @@ class Image {
         return bytes;
       case Format.bgr:
         var bytes = Uint8List(width * height * 3);
-        for (var i = 0, j = 0, len = bytes.length; i < len; i += 4, j += 3) {
+        for (var i = 0, j = 0, len = bytes.length; j < len; i += 4, j += 3) {
           bytes[j + 0] = rgba[i + 2];
           bytes[j + 1] = rgba[i + 1];
           bytes[j + 2] = rgba[i + 0];


### PR DESCRIPTION
The Image.getBytes function which outputs images in `Format.bgr` and `Format.rgb` actually remove the last 25% of the image. This is because the function stops early, because of `i < len` instead of `j < len`

I have created an example below:
![Frame 4](https://user-images.githubusercontent.com/24711048/92789709-022ddb80-f3a3-11ea-87a7-cddd729e506e.png)
