### PR TITLE
Fix GifEncoder for variable fps

### DIFF
--- a/lib/src/formats/gif_decoder.dart
+++ b/lib/src/formats/gif_decoder.dart
@@ -196,7 +196,7 @@ class GifDecoder extends Decoder {
         lastImage = image;
       }
 
-      lastImage.duration = frame.duration;
+      lastImage.duration = frame.duration * 10; // Convert 1/100 sec to ms.
       anim.addFrame(lastImage);
     }
 

--- a/lib/src/formats/gif_encoder.dart
+++ b/lib/src/formats/gif_encoder.dart
@@ -16,15 +16,12 @@ class GifEncoder extends Encoder {
   /// After the last frame has been added, [finish] is required to be called.
   /// Optional frame [duration] is in 1/100 sec.
   void addFrame(Image image, {int duration}) {
-    if (duration != null) {
-      delay = duration;
-    }
-
     if (output == null) {
       output = OutputBuffer();
 
       _lastColorMap = NeuralQuantizer(image, samplingFactor: samplingFactor);
       _lastImage = _lastColorMap.getIndexMap(image);
+      _lastImageDuration = duration;
 
       _width = image.width;
       _height = image.height;
@@ -43,6 +40,7 @@ class GifEncoder extends Encoder {
 
     _lastColorMap = NeuralQuantizer(image, samplingFactor: samplingFactor);
     _lastImage = _lastColorMap.getIndexMap(image);
+    _lastImageDuration = duration;
   }
 
   /// Encode the images that were added with [addFrame].
@@ -310,7 +308,7 @@ class GifEncoder extends Encoder {
         0 | // 7   user input - 0 = none
         transparency); // 8   transparency flag
 
-    output.writeUint16(delay); // delay x 1/100 sec
+    output.writeUint16(_lastImageDuration ?? delay); // delay x 1/100 sec
     output.writeByte(0); // transparent color index
     output.writeByte(0); // block terminator
   }
@@ -326,6 +324,7 @@ class GifEncoder extends Encoder {
   }
 
   Uint8List _lastImage;
+  int _lastImageDuration;
   NeuralQuantizer _lastColorMap;
   int _width;
   int _height;

--- a/lib/src/formats/gif_encoder.dart
+++ b/lib/src/formats/gif_encoder.dart
@@ -92,7 +92,10 @@ class GifEncoder extends Encoder {
   List<int> encodeAnimation(Animation anim) {
     repeat = anim.loopCount;
     for (var f in anim) {
-      addFrame(f, duration: f.duration);
+      addFrame(
+        f,
+        duration: f.duration ~/ 10, // Convert ms to 1/100 sec.
+      );
     }
     return finish();
   }

--- a/lib/src/formats/gif_encoder.dart
+++ b/lib/src/formats/gif_encoder.dart
@@ -14,6 +14,7 @@ class GifEncoder extends Encoder {
 
   /// This adds the frame passed to [image].
   /// After the last frame has been added, [finish] is required to be called.
+  /// Optional frame [duration] is in 1/100 sec.
   void addFrame(Image image, {int duration}) {
     if (duration != null) {
       delay = duration;

--- a/test/gif_test.dart
+++ b/test/gif_test.dart
@@ -79,6 +79,28 @@ void main() {
       expect(anim2.loopCount, equals(10));
     });
 
+    test('encodeAnimation with variable FPS', () {
+      final anim = Animation();
+      for (var i = 1; i <= 3; i++) {
+        final image = Image(480, 120);
+        image.duration = i * 1000;
+        drawString(image, arial_48, 100, 60, i.toString());
+        anim.addFrame(image);
+      }
+
+      final gif = encodeGifAnimation(anim);
+      File('.dart_tool/out/gif/encodeAnimation_variable_fps.gif')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(gif);
+
+      final anim2 = GifDecoder().decodeAnimation(gif);
+      expect(anim2.length, equals(3));
+      expect(anim2.loopCount, equals(0));
+      expect(anim2[0].duration, equals(1000));
+      expect(anim2[1].duration, equals(2000));
+      expect(anim2[2].duration, equals(3000));
+    });
+
     test('encodeImage', () {
       final bytes = File('test/res/jpg/jpeg444.jpg').readAsBytesSync();
       final image = JpegDecoder().decodeImage(bytes);

--- a/test/gif_test.dart
+++ b/test/gif_test.dart
@@ -84,7 +84,7 @@ void main() {
       for (var i = 1; i <= 3; i++) {
         final image = Image(480, 120);
         image.duration = i * 1000;
-        drawString(image, arial_48, 100, 60, i.toString());
+        drawString(image, arial_24, 50, 50, 'This frame is $i second(s) long');
         anim.addFrame(image);
       }
 


### PR DESCRIPTION
Fixes https://github.com/brendan-duncan/image/issues/256

**Additional effect:**
Specifying duration `addFrame(frame, duration: ...)` would only change duration of that frame.
I believe it makes more sense if the following `addFrame(nextFrame)` use default duration that was given to `GifEncoder`.
```dart
final encoder = GifEncoder(delay: 40);

encoder.addFrame(frame1); // 400ms long

encoder.addFrame(frame2, duration: 80); // 800ms long

encoder.addFrame(frame3); // 400ms long (before it would be 800ms)

encoder.addFrame(frame4); // 400ms long (before it would be 800ms)
...
```

Let me know if this additional effect is desirable or not. :)