### PR TITLE
fix quality parameter out of range

### DIFF
--- a/lib/src/formats/jpeg_encoder.dart
+++ b/lib/src/formats/jpeg_encoder.dart
@@ -19,7 +19,7 @@ class JpegEncoder extends Encoder {
   }
 
   void setQuality(int quality) {
-    quality = quality.clamp(0, 100).toInt();
+    quality = quality.clamp(1, 100).toInt();
 
     if (currentQuality == quality) {
       // don't re-calc if unchanged


### PR DESCRIPTION
The lower bound of the quality parameter should be 1 and not 0, because it is used as divisor. The original javascript implementation clamps to (1,100) as well.