### PR TITLE
Bump archive package version to ^3.1.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  archive: ^3.0.0
+  archive: ^3.1.2
   meta: ^1.3.0
   xml: ^5.0.0
 


### PR DESCRIPTION
New archive package version is required to avoid build errors. See #334 for more information.