### PR TITLE
jpeg comment - support not strict utf8 text

### DIFF
--- a/lib/src/util/input_buffer.dart
+++ b/lib/src/util/input_buffer.dart
@@ -142,7 +142,7 @@ class InputBuffer {
     while (!isEOS) {
       final c = readByte();
       if (c == 0) {
-        return utf8.decode(codes);
+        return utf8.decode(codes, allowMalformed: true);
       }
       codes.add(c);
     }


### PR DESCRIPTION
If jpeg comment is not properyl utf8 encoded, returned text is null 
Activating alloweMalformed would help a lot on non-utf8 text.


