### PR TITLE
fix bmp encoder: line padding

### DIFF
--- a/lib/src/formats/bmp_encoder.dart
+++ b/lib/src/formats/bmp_encoder.dart
@@ -43,6 +43,16 @@ class BmpEncoder extends Encoder {
         if (bytesPerPixel == 4)
           out.writeByte(getAlpha(rgba));
       }
+
+      // Line padding
+      if (bytesPerPixel != 4) {
+        var padding = 4 - ((image.width * bytesPerPixel) % 4);
+        if (padding != 4) {
+          out.writeBytes(List.generate(padding - 1, (index) => 0x00));
+
+          out.writeByte(0xFF);
+        }
+      }
     }
 
     return out.getBytes();


### PR DESCRIPTION
The bmp format requires having a number of bytes multiple of 4 per pixel line