### PR TITLE
Fix `characterXAdvance`

### DIFF
--- a/lib/src/bitmap_font.dart
+++ b/lib/src/bitmap_font.dart
@@ -112,7 +112,7 @@ class BitmapFont {
       return 0;
     }
     final c = ch.codeUnits[0];
-    if (!characters.containsKey(ch)) {
+    if (!characters.containsKey(c)) {
       return base ~/ 2;
     }
     return characters[c]!.xadvance;


### PR DESCRIPTION
The method `characterXAdvance` is accessing the `characters` table with the wrong variable!

It should be accessed with the variable `c` (code unit int) and not `ch` (the character): https://github.com/brendan-duncan/image/blob/fe4a1fb6809ac0fcd4d4a36cfe1eab3a1862bd6d/lib/src/bitmap_font.dart#L115