### PR TITLE
Fix `PixelRangeIterator` skipping last line

### DIFF
--- a/lib/src/image/pixel_range_iterator.dart
+++ b/lib/src/image/pixel_range_iterator.dart
@@ -19,7 +19,7 @@ class PixelRangeIterator extends Iterator<Pixel> {
   bool moveNext() {
     if ((pixel.x + 1) > x2) {
       pixel.setPosition(x1, pixel.y + 1);
-      return pixel.y < y2;
+      return pixel.y <= y2;
     }
     return pixel.moveNext();
   }


### PR DESCRIPTION
The `PixelRangeIterator.moveNext` was skipping the last line.

- Since `x2` is an inclusive coordinates, `y2` should also be an inclusive coordinate.
- Since `PixelRangeIterator` constructor computes `y2 = y + height - 1`.