### PR TITLE
Deep copy ifd

### DIFF
--- a/lib/src/exif/ifd_directory.dart
+++ b/lib/src/exif/ifd_directory.dart
@@ -27,6 +27,7 @@ class IfdDirectory {
 
   void copy(IfdDirectory other) {
     other.data.forEach((tag, value) => data[tag] = value.clone());
+    other.sub.directories.forEach((tag, value) => sub.directories[tag] = value.clone());
   }
 
   /// The size in bytes of the data written by this directory. Can be used to

--- a/test/exif/exif_tests.dart
+++ b/test/exif/exif_tests.dart
@@ -34,9 +34,10 @@ void main() {
       final out = OutputBuffer();
       exif.write(out);
 
-      final exif2 = ExifData();
+      final exif1 = ExifData();
       final input = InputBuffer(out.getBytes());
-      exif2.read(input);
+      exif1.read(input);
+      final exif2 = exif1.clone();
 
       expect(exif2.imageIfd.values.length, equals(exif.imageIfd.values.length));
       for (int i = 0; i < exif2.imageIfd.values.length; ++i) {


### PR DESCRIPTION
I noticed that not all the EXIF data was getting to my new file.  This fix does a deep copy on the sub-directories, and adds a test to make sure that clone copies everything.