### PR TITLE
Add 4:2:0 chroma subsampling format in JpegEncoder

### DIFF
--- a/doc/formats.md
+++ b/doc/formats.md
@@ -59,9 +59,9 @@ Image? decodeJpg(Uint8List bytes);
 // Decode an image file directly from the file on platforms that support dart:io.
 Future<Image?> decodeJpgFile(String path) async;
 
-Uint8List encodeJpg(Image image, { int quality = 100 });
+Uint8List encodeJpg(Image image, { int quality = 100, chroma: JpegChroma.yuv444 });
 
-Future<bool> encodeJpgFile(String path, Image image, { int quality = 100 }) async;
+Future<bool> encodeJpgFile(String path, Image image, { int quality = 100, chroma: JpegChroma.yuv444 }) async;
 ```
 ### PNG: decoding, encoding
 ```dart

--- a/lib/src/formats/formats.dart
+++ b/lib/src/formats/formats.dart
@@ -248,16 +248,23 @@ Future<Image?> decodeJpgFile(String path) async {
 }
 
 /// Encode an [image] to the JPEG format.
-Uint8List encodeJpg(Image image, {int quality = 100}) =>
-    JpegEncoder(quality: quality).encode(image);
+Uint8List encodeJpg(
+  Image image, {
+  int quality = 100,
+  JpegChroma chroma = JpegChroma.yuv444,
+}) => JpegEncoder(quality: quality).encode(image, chroma: chroma);
 
 /// Encode an [image] to a JPG file at the given [path].
-Future<bool> encodeJpgFile(String path, Image image,
-    {int quality = 100}) async {
+Future<bool> encodeJpgFile(
+  String path,
+  Image image, {
+  int quality = 100,
+  JpegChroma chroma = JpegChroma.yuv444,
+}) async {
   if (!supportsFileAccess()) {
     return false;
   }
-  final bytes = JpegEncoder(quality: quality).encode(image);
+  final bytes = JpegEncoder(quality: quality).encode(image, chroma: chroma);
   return writeFile(path, bytes);
 }
 

--- a/lib/src/formats/jpeg_encoder.dart
+++ b/lib/src/formats/jpeg_encoder.dart
@@ -70,11 +70,13 @@ class JpegEncoder extends Encoder {
 
     if (chroma == JpegChroma.yuv444) {
       // 4:4:4 chroma: process 8x8 blocks.
-      final ydu = Float32List(64), udu = Float32List(64), vdu = Float32List(64);
+      final ydu = Float32List(64);
+      final udu = Float32List(64);
+      final vdu = Float32List(64);
 
       for (int y = 0; y < height; y += 8) {
         for (int x = 0; x < width; x += 8) {
-          _yuv444(image, x, y, width, height, ydu, udu, vdu);
+          _calculateYUV(image, x, y, width, height, ydu, udu, vdu);
           dcy = _processDU(fp, ydu, _fdtblY, dcy, _ydcHuffman, _yacHuffman);
           dcu = _processDU(fp, udu, _fdtblUv, dcu, _uvdcHuffman, _uvacHuffman);
           dcv = _processDU(fp, vdu, _fdtblUv, dcv, _uvdcHuffman, _uvacHuffman);
@@ -85,14 +87,15 @@ class JpegEncoder extends Encoder {
       final ydu = List<Float32List>.generate(4, (i) => Float32List(64));
       final udu = List<Float32List>.generate(4, (i) => Float32List(64));
       final vdu = List<Float32List>.generate(4, (i) => Float32List(64));
-      final sudu = Float32List(64), svdu = Float32List(64);
+      final sudu = Float32List(64);
+      final svdu = Float32List(64);
 
       for (int y = 0; y < height; y += 16) {
         for (int x = 0; x < width; x += 16) {
-          _yuv444(image, x, y, width, height, ydu[0], udu[0], vdu[0]);
-          _yuv444(image, x + 8, y, width, height, ydu[1], udu[1], vdu[1]);
-          _yuv444(image, x, y + 8, width, height, ydu[2], udu[2], vdu[2]);
-          _yuv444(image, x + 8, y + 8, width, height, ydu[3], udu[3], vdu[3]);
+          _calculateYUV(image, x, y, width, height, ydu[0], udu[0], vdu[0]);
+          _calculateYUV(image, x + 8, y, width, height, ydu[1], udu[1], vdu[1]);
+          _calculateYUV(image, x, y + 8, width, height, ydu[2], udu[2], vdu[2]);
+          _calculateYUV(image, x + 8, y + 8, width, height, ydu[3], udu[3], vdu[3]);
           _downsampleDU(sudu, udu[0], udu[1], udu[2], udu[3]);
           _downsampleDU(svdu, vdu[0], vdu[1], vdu[2], vdu[3]);
           dcy = _processDU(fp, ydu[0], _fdtblY, dcy, _ydcHuffman, _yacHuffman);
@@ -118,7 +121,7 @@ class JpegEncoder extends Encoder {
     return fp.getBytes();
   }
 
-  void _yuv444(
+  void _calculateYUV(
     Image image,
     int x,
     int y,

--- a/lib/src/formats/jpeg_encoder.dart
+++ b/lib/src/formats/jpeg_encoder.dart
@@ -594,7 +594,7 @@ class JpegEncoder extends Encoder {
       ..writeBytes(exifBytes);
   }
 
-  void _writeSOF0( OutputBuffer out, int width, int height, JpegChroma chroma) {
+  void _writeSOF0(OutputBuffer out, int width, int height, JpegChroma chroma) {
     _writeMarker(out, JpegMarker.sof0);
     out
       ..writeUint16(17) // length, truecolor YUV JPG

--- a/test/formats/jpeg_test.dart
+++ b/test/formats/jpeg_test.dart
@@ -45,12 +45,20 @@ void main() async {
           ..writeAsBytesSync(encodePng(image));
       });
 
-      test('encode', () {
+      test('encode (default 4:4:4 chroma)', () {
         final fb = File('test/_data/jpg/buck_24.jpg').readAsBytesSync();
         final image = JpegDecoder().decode(fb)!;
         File('$testOutputPath/jpg/encode.png')
           ..createSync(recursive: true)
           ..writeAsBytesSync(encodeJpg(image));
+      });
+
+      test('encode (4:2:0 chroma)', () {
+        final fb = File('test/_data/jpg/buck_24.jpg').readAsBytesSync();
+        final image = JpegDecoder().decode(fb)!;
+        File('$testOutputPath/jpg/encode.png')
+          ..createSync(recursive: true)
+          ..writeAsBytesSync(encodeJpg(image, chroma: JpegChroma.yuv420));
       });
 
       test('progressive', () {


### PR DESCRIPTION
This PR adds support for encoding JPEG using 4:2:0 chroma subsampling to achieve better compression.

The following option is added to `JpegEncoder.encode()`:
```
enum JpegChroma {
  yuv444,
  yuv420,
}
```