### PR TITLE
Round resized image size

### DIFF
--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -29,11 +29,10 @@ Image copyResize(Image src,
 
   // this block sets [width] and [height] if null or negative.
   if (height == null || height <= 0) {
-    height = (width! * (src.height / src.width)).toInt();
+    height = (width! * (src.height / src.width)).round();
   }
-
   if (width == null || width <= 0) {
-    width = (height * (src.width / src.height)).toInt();
+    width = (height * (src.width / src.height)).round();
   }
 
   if (width == src.width && height == src.height) {


### PR DESCRIPTION
## Motivation

I noticed that when I did `img.copyResized(image, width:20)` on an `image` of size e.g. `500x499`, then the resulting image would have size `20x19` not `20x20` as expected. I looked into the code and the height uses the `toInt()` function which always rounds down (i.e. `20x19.99999` gets rounded down to `20x19`).