### PR TITLE
Implement Iterator instead of extend it.

### DIFF
--- a/lib/src/color/channel_iterator.dart
+++ b/lib/src/color/channel_iterator.dart
@@ -1,7 +1,7 @@
 import 'color.dart';
 
 /// An iterator over the channels of a [Color].
-class ChannelIterator extends Iterator<num> {
+class ChannelIterator implements Iterator<num> {
   int index = -1;
   Color color;
 

--- a/lib/src/image/pixel.dart
+++ b/lib/src/image/pixel.dart
@@ -2,7 +2,7 @@ import '../color/color.dart';
 import 'image_data.dart';
 import 'pixel_undefined.dart';
 
-abstract class Pixel extends Iterator<Pixel> implements Color {
+abstract class Pixel implements Iterator<Pixel>, Color {
   /// [undefined] is used to represent an invalid pixel.
   static Pixel get undefined => PixelUndefined();
 

--- a/lib/src/image/pixel_range_iterator.dart
+++ b/lib/src/image/pixel_range_iterator.dart
@@ -1,6 +1,6 @@
 import 'pixel.dart';
 
-class PixelRangeIterator extends Iterator<Pixel> {
+class PixelRangeIterator implements Iterator<Pixel> {
   Pixel pixel;
   int x1;
   int y1;


### PR DESCRIPTION
Iterator became an interface class in dart 3 and therefore can not be extended.