### PR TITLE
add copy_expand_canvas to image.dart

### DIFF
--- a/lib/image.dart
+++ b/lib/image.dart
@@ -223,6 +223,7 @@ export 'src/transform/copy_resize_crop_square.dart';
 export 'src/transform/copy_rotate.dart';
 export 'src/transform/flip.dart';
 export 'src/transform/trim.dart';
+export 'src/transform/copy_expand_canvas.dart';
 export 'src/util/clip_line.dart';
 export 'src/util/color_util.dart';
 export 'src/util/file_access.dart';


### PR DESCRIPTION
the files of copy_expand_canvas are there but need to add it to image.dart export to use the function