### PR TITLE
Fix drawString wrap break line

### DIFF
--- a/lib/src/draw/draw_string.dart
+++ b/lib/src/draw/draw_string.dart
@@ -104,7 +104,7 @@ Image drawString(Image image, String string,
   }
 
   final origX = sx;
-  final substrings = string.split(RegExp(r"[(\n|\r)]"));
+  final substrings = string.split(RegExp(r"[\n|\r]"));
 
   for (var ss in substrings) {
     final chars = ss.codeUnits;

--- a/lib/src/draw/draw_string.dart
+++ b/lib/src/draw/draw_string.dart
@@ -28,17 +28,15 @@ Image drawString(Image image, String string,
   var stringWidth = 0;
   var stringHeight = 0;
 
-  if (x == null || y == null) {
-    final chars = string.codeUnits;
-    for (var c in chars) {
-      if (!font.characters.containsKey(c)) {
-        continue;
-      }
-      final ch = font.characters[c]!;
-      stringWidth += ch.xAdvance;
-      if (ch.height + ch.yOffset > stringHeight) {
-        stringHeight = ch.height + ch.yOffset;
-      }
+  final chars = string.codeUnits;
+  for (var c in chars) {
+    if (!font.characters.containsKey(c)) {
+      continue;
+    }
+    final ch = font.characters[c]!;
+    stringWidth += ch.xAdvance;
+    if (ch.height + ch.yOffset > stringHeight) {
+      stringHeight = ch.height + ch.yOffset;
     }
   }
 


### PR DESCRIPTION
The line break didn't work when either x or y was defined. Remove the condition that checks if either of them is not null.