### PR TITLE
Add a start method to the PngEncoder.

### DIFF
--- a/lib/src/formats/png_encoder.dart
+++ b/lib/src/formats/png_encoder.dart
@@ -92,6 +92,17 @@ class PngEncoder extends Encoder {
     }
   }
 
+  /// Start encoding a PNG.
+  ///
+  /// Call this method once before calling addFrame.
+  void start(int frameCount) {
+      _frames = frameCount;
+      isAnimated = frameCount > 1;
+  }
+
+  /// Finish encoding a PNG, and return the resulting bytes.
+  ///
+  /// Call this method to finalize the encoding, after all addFrame calls.
   Uint8List? finish() {
     Uint8List? bytes;
 
@@ -116,11 +127,10 @@ class PngEncoder extends Encoder {
   @override
   Uint8List encode(Image image, {bool singleFrame = false}) {
     if (!image.hasAnimation || singleFrame) {
-      isAnimated = false;
+      start(1);
       addFrame(image);
     } else {
-      isAnimated = true;
-      _frames = image.frames.length;
+      start(image.frames.length);
       repeat = image.loopCount;
 
       if (image.hasPalette) {

--- a/test/formats/png_test.dart
+++ b/test/formats/png_test.dart
@@ -410,6 +410,20 @@ void main() {
           ..writeAsBytesSync(png);
       });
 
+      test('encodeAnimation with mulitple single frame Images', () {
+        final encoder = PngEncoder()..start(10);
+        for (var i = 0; i < 10; i++) {
+          final frame = Image(width: 480, height: 120)..loopCount = 10;
+          drawString(frame, i.toString(), font: arial48, x: 100, y: 60);
+          encoder.addFrame(frame);
+        }
+
+        final png = encoder.finish()!;
+        File('$testOutputPath/png/encodeAnimation.png')
+          ..createSync(recursive: true)
+          ..writeAsBytesSync(png);
+      });
+
       test('textData', () {
         final img = Image(width: 16, height: 16, textData: {"foo": "bar"});
         final png = PngEncoder().encode(img);


### PR DESCRIPTION
This allows callers to make animated PNG files by calling addFrame directly in their own frame loops, so additional code can be exectuted in between frame processing, such as updating a progress bar.