### PR TITLE
Mitigate bad ifd offset.

### DIFF
--- a/lib/src/exif/exif_data.dart
+++ b/lib/src/exif/exif_data.dart
@@ -286,7 +286,12 @@ class ExifData extends IfdContainer {
       directories['ifd$index'] = directory;
       index++;
 
-      ifdOffset = block.readUint32();
+      final nextIfdOffset = block.readUint32();
+      if (nextIfdOffset == ifdOffset) {
+        break;
+      } else {
+        ifdOffset = nextIfdOffset;
+      }
     }
 
     const subTags = {


### PR DESCRIPTION
I found a file that would cause the jpeg decoder to get stuck in an infinite loop while reading the exif IFDs.

If the final offset in the IFD points back to itself, the reader gets stuck in an infinite loop: https://github.com/brendan-duncan/image/blob/c4a8783e5a1d5e80b93ec33c571b1749a5951713/lib/src/exif/exif_data.dart#L289

I've attached a zipped version of the jpg with the bad exif (not sure if Github re-processes the image so I zipped it) in case you want to try the bad file and see how it is handled.

[bad_exif.jpg.zip](https://github.com/brendan-duncan/image/files/13883359/bad_exif.jpg.zip)


