### PR TITLE
Optimize copying of bytes in Image.fromBytes

### DIFF
--- a/lib/src/image/image.dart
+++ b/lib/src/image/image.dart
@@ -279,7 +279,7 @@ class Image extends Iterable<Pixel> {
     var dOff = 0;
     var bOff = 0;
     for (int y = 0; y < height; ++y, bOff += rowStride, dOff += dataStride) {
-      final bRow = fromBytes.getRange(bOff, bOff + stride);
+      final bRow = Uint8List.sublistView(fromBytes, bOff, bOff + stride);
       toBytes.setRange(dOff, dOff + dataStride, bRow);
     }
 


### PR DESCRIPTION
Dart 3.2 contains an optimization where setRange on typed data is performed by a simple memcpy when copying between two typed lists. See https://dart-review.googlesource.com/c/sdk/+/319521.

The optimization is only applied when the iterable passed to setRange is typed data.

This change speeds up fromBytes massively for bigger images. Copying a 10000x10000 pixel image takes ~0.13s instead of ~3.2s on my machine.