### PR TITLE
feat: allow to use Command.drawString with no required position

### DIFF
--- a/lib/src/command/command.dart
+++ b/lib/src/command/command.dart
@@ -527,8 +527,8 @@ class Command {
 
   void drawString(String string,
       {required BitmapFont font,
-      required int x,
-      required int y,
+      int? x,
+      int? y,
       Color? color,
       bool wrap = false,
       bool rightJustify = false,


### PR DESCRIPTION
As for `DrawStringCmd` and `drawString`, this PR allows to call `Command.drawString` with no required coordinates