### PR TITLE
Bump archive package version to ^3.6.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  archive: ^3.4.0
+  archive: ^3.6.1
   meta: ^1.3.0
   xml: ^6.0.1
 


### PR DESCRIPTION
As the new Dart version(3.5) is now released, it has deprecated Uint8ListView ([dart-lang/sdk/#45115](https://github.com/dart-lang/sdk/issues/45115)) which throws an error while building a flutter app from the package _**archive**_.

New **_archive_** package version is now required to avoid build errors. 
The author of the package **_archive_** migrated the following changes at the version of 3.5.0 ([related-Issue](https://github.com/brendan-duncan/archive/issues/346), [related-commit](6b29b9b567e432b5f8fc6b696aac427bd2d2eb2c))

Thanks.

