### PR TITLE
Also include number of components in the jpeg info

### DIFF
--- a/lib/src/formats/jpeg/jpeg_data.dart
+++ b/lib/src/formats/jpeg/jpeg_data.dart
@@ -141,7 +141,8 @@ class JpegData {
     if (frame != null) {
       info
         ..width = frame!.samplesPerLine!
-        ..height = frame!.scanLines!;
+        ..height = frame!.scanLines!
+        ..numComponents = frame!.components.length;
     }
     frame = null;
     frames.clear();

--- a/lib/src/formats/jpeg/jpeg_info.dart
+++ b/lib/src/formats/jpeg/jpeg_info.dart
@@ -10,4 +10,7 @@ class JpegInfo implements DecodeInfo {
   int get numFrames => 1;
   @override
   Color? get backgroundColor => null;
+
+  /// The number of components in the image
+  int numComponents = 0;
 }


### PR DESCRIPTION
As the number of components is known when we have parsed the frame information, we can return it in the info. This avoids having to read the full image