### PR TITLE
Improve copy resize efficiency and bug fix

### DIFF
--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -83,6 +83,11 @@ Image copyResize(Image src,
   for (var x = 0; x < w; ++x) {
     scaleX[x] = (x * dx).toInt();
   }
+  final scaleY = Int32List(h);
+  final dy = src.height / h;
+  for (var y = 0; y < h; ++y) {
+    scaleY[y] = (y * dy).toInt();
+  }
 
   Image? firstFrame;
   final numFrames = src.numFrames;
@@ -143,10 +148,16 @@ Image copyResize(Image src,
           }
         }
       } else {
+        final srcPixel = frame.getPixelSafe(0, 0);
         for (var y = 0; y < h; ++y) {
-          final y2 = (y * dy).toInt();
           for (var x = 0; x < w; ++x) {
-            dst.setPixel(x1 + x, y1 + y, frame.getPixel(scaleX[x], y2));
+            frame.getPixel(scaleX[x], scaleY[y], srcPixel);
+            dst.setPixelRgba(
+                x1 + x, y1 + y, srcPixel.r, srcPixel.g, srcPixel.b, srcPixel.a);
+            // Not calling setPixel which triggers runtime type checking
+            // mainly for hasPalette routine. Palette images are treated in
+            // the above if-else block.
+            //dst.setPixel(x1 + x, y1 + y, frame.getPixel(scaleX[x], y2));
           }
         }
       }

--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -187,10 +187,11 @@ Image copyResize(Image src,
           final nx = (ix + 1).clamp(0, frame.width - 1);
           final ny = (iy + 1).clamp(0, frame.height - 1);
 
-          frame.getPixel(ix, iy, icc);
-          frame.getPixel(ix, ny, icn);
-          frame.getPixel(nx, iy, inc);
-          frame.getPixel(nx, ny, inn);
+          frame
+            ..getPixel(ix, iy, icc)
+            ..getPixel(ix, ny, icn)
+            ..getPixel(nx, iy, inc)
+            ..getPixel(nx, ny, inn);
 
           dst.setPixelRgba(
               x1 + x,

--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -106,6 +106,7 @@ Image copyResize(Image src,
     }
 
     if (interpolation == Interpolation.average) {
+      final srcPixel = frame.getPixelSafe(0, 0);
       for (var y = 0; y < h; ++y) {
         final ay1 = (y * dy).toInt();
         var ay2 = ((y + 1) * dy).toInt();
@@ -127,15 +128,14 @@ Image copyResize(Image src,
           var np = 0;
           for (var sy = ay1; sy < ay2; ++sy) {
             for (var sx = ax1; sx < ax2; ++sx, ++np) {
-              final s = frame.getPixel(sx, sy);
-              r += s.r;
-              g += s.g;
-              b += s.b;
-              a += s.a;
+              frame.getPixel(sx, sy, srcPixel);
+              r += srcPixel.r;
+              g += srcPixel.g;
+              b += srcPixel.b;
+              a += srcPixel.a;
             }
           }
-          dst.setPixel(
-              x1 + x, y1 + y, dst.getColor(r / np, g / np, b / np, a / np));
+          dst.setPixelRgba(x1 + x, y1 + y, r / np, g / np, b / np, a / np);
         }
       }
     } else if (interpolation == Interpolation.nearest) {

--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -168,9 +168,9 @@ Image copyResize(Image src,
         for (var x = 0; x < w; ++x) {
           final sx2 = x * dx;
           dst.setPixel(
-              x,
-              y,
-              frame.getPixelInterpolate(x1 + sx2, y1 + sy2,
+              x1 + x,
+              y1 + y,
+              frame.getPixelInterpolate(sx2, sy2,
                   interpolation: interpolation));
         }
       }

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -279,6 +279,35 @@ void main() {
         ..writeAsBytesSync(encodePng(i0));
     });
 
+    test('copyResize linear larger color correctness', () {
+      final img =
+          decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
+      final i0 =
+          copyResize(img, width: 272, interpolation: Interpolation.linear);
+      // 256x256 => 272x272 = 1.0625 times each side
+      expect(i0.width, equals(272));
+      expect(i0.height, equals(272));
+      for (int y = 0; y < 272; y += 8) {
+        for (int x = 0; x < 272; x += 12) {
+          final out = i0.getPixel(x, y);
+          final ori = img.getPixel((x / 1.0625).toInt(), (y / 1.0625).toInt());
+          expect(out.r, closeTo(ori.r, 7),
+              reason:
+                  'Pixel color red at ($x,$y) in resized image is not correct');
+          expect(out.g, closeTo(ori.g, 7),
+              reason:
+                  'Pixel color red at ($x,$y) in resized image is not correct');
+          expect(out.b, closeTo(ori.b, 7),
+              reason:
+                  'Pixel color red at ($x,$y) in resized image is not correct');
+        }
+      }
+
+      File('$testOutputPath/transform/copyResize_color_linear_larger_1.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(encodePng(i0));
+    });
+
     test('copyResize cubic smaller maintainAspect color correctness', () {
       final img =
           decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -296,10 +296,10 @@ void main() {
                   'Pixel color red at ($x,$y) in resized image is not correct');
           expect(out.g, closeTo(ori.g, 7),
               reason:
-                  'Pixel color green at ($x,$y) in resized image is not correct');
+                  'Pixelcolor green at($x,$y) in resized image is not correct');
           expect(out.b, closeTo(ori.b, 7),
               reason:
-                  'Pixel color blue at ($x,$y) in resized image is not correct');
+                  'Pixelcolor blue at($x,$y) in resized image is not correct');
         }
       }
 

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -234,5 +234,93 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsBytesSync(encodePng(i0));
     });
+
+    test('copyResize linear smaller maintainAspect color correctness', () {
+      final img =
+          decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
+      final i0 = copyResize(img,
+          width: 128,
+          height: 256,
+          maintainAspect: true,
+          backgroundColor: ColorUint8.fromList([253, 254, 252]),
+          interpolation: Interpolation.linear);
+      expect(i0.width, equals(128));
+      expect(i0.height, equals(256));
+
+      //  Intended output, O is the resized original image, B is background:
+      //  BBBBBBB
+      //  BBBBBBB
+      //  OOOOOOO
+      //  OOOOOOO
+      //  OOOOOOO
+      //  OOOOOOO
+      //  BBBBBBB
+      //  BBBBBBB
+      for (int y = 64; y < 64 + 128; y += 6) {
+        for (int x = 0; x < 128; x += 6) {
+          expect(i0.getPixel(x, y),
+              equals(img.getPixel((x * 2).toInt(), ((y - 64) * 2).toInt())),
+              reason: 'Pixel color at ($x,$y) in resized image is not correct');
+        }
+      }
+
+      // There should be empty space denoted by backgroundColor
+      expect(i0.getPixel(0, 63), equals(ColorUint8.fromList([253, 254, 252])));
+      expect(
+          i0.getPixel(127, 63), equals(ColorUint8.fromList([253, 254, 252])));
+      expect(i0.getPixel(0, 64 + 128),
+          equals(ColorUint8.fromList([253, 254, 252])));
+      expect(i0.getPixel(127, 64 + 128),
+          equals(ColorUint8.fromList([253, 254, 252])));
+
+      File(
+          '$testOutputPath/transform/copyResize_color_linear_smaller_aspect_1.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(encodePng(i0));
+    });
+
+    test('copyResize linear smaller maintainAspect color correctness', () {
+      final img =
+          decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
+      final i0 = copyResize(img,
+          width: 128,
+          height: 256,
+          maintainAspect: true,
+          backgroundColor: ColorUint8.fromList([253, 254, 252]),
+          interpolation: Interpolation.cubic);
+      expect(i0.width, equals(128));
+      expect(i0.height, equals(256));
+
+      //  Intended output, O is the resized original image, B is background:
+      //  BBBBBBB
+      //  BBBBBBB
+      //  OOOOOOO
+      //  OOOOOOO
+      //  OOOOOOO
+      //  OOOOOOO
+      //  BBBBBBB
+      //  BBBBBBB
+      for (int y = 64; y < 64 + 128; y += 6) {
+        for (int x = 0; x < 128; x += 6) {
+          expect(i0.getPixel(x, y),
+              equals(img.getPixel((x * 2).toInt(), ((y - 64) * 2).toInt())),
+              reason: 'Pixel color at ($x,$y) in resized image is not correct');
+        }
+      }
+
+      // There should be empty space denoted by backgroundColor
+      expect(i0.getPixel(0, 63), equals(ColorUint8.fromList([253, 254, 252])));
+      expect(
+          i0.getPixel(127, 63), equals(ColorUint8.fromList([253, 254, 252])));
+      expect(i0.getPixel(0, 64 + 128),
+          equals(ColorUint8.fromList([253, 254, 252])));
+      expect(i0.getPixel(127, 64 + 128),
+          equals(ColorUint8.fromList([253, 254, 252])));
+
+      File(
+          '$testOutputPath/transform/copyResize_color_cubic_smaller_aspect_1.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(encodePng(i0));
+    });
   });
 }

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -173,5 +173,43 @@ void main() {
       await encodePngFile(
           '$testOutputPath/transform/copyResize_palette.png', i0);
     });
+
+    test('copyResize nearest smaller color correctness', () {
+      final img =
+          decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
+      final i0 = copyResize(img, width: 64); // 256x256 => 64x64
+      expect(i0.width, equals(64));
+      expect(i0.height, equals(64));
+      for (int y = 0; y < 64; y += 6) {
+        for (int x = 0; x < 64; x += 8) {
+          expect(i0.getPixel(x, y), equals(img.getPixel(x * 4, y * 4)),
+              reason: 'Pixel color at ($x,$y) in resized image is not correct');
+        }
+      }
+      File('$testOutputPath/transform/copyResize_color_nearest_smaller_1.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(encodePng(i0));
+    });
+
+    test('copyResize nearest larger color correctness', () {
+      final img =
+          decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
+      final i0 = copyResize(img,
+          width: 360); // 256x256 => 360x360 = 1.40625 times each side
+      expect(i0.width, equals(360));
+      expect(i0.height, equals(360));
+      for (int y = 0; y < 360; y += 8) {
+        for (int x = 0; x < 360; x += 12) {
+          expect(
+              i0.getPixel(x, y),
+              equals(
+                  img.getPixel((x / 1.40625).toInt(), (y / 1.40625).toInt())),
+              reason: 'Pixel color at ($x,$y) in resized image is not correct');
+        }
+      }
+      File('$testOutputPath/transform/copyResize_color_nearest_larger_1.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(encodePng(i0));
+    });
   });
 }

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -296,10 +296,10 @@ void main() {
                   'Pixel color red at ($x,$y) in resized image is not correct');
           expect(out.g, closeTo(ori.g, 7),
               reason:
-                  'Pixel color red at ($x,$y) in resized image is not correct');
+                  'Pixel color green at ($x,$y) in resized image is not correct');
           expect(out.b, closeTo(ori.b, 7),
               reason:
-                  'Pixel color red at ($x,$y) in resized image is not correct');
+                  'Pixel color blue at ($x,$y) in resized image is not correct');
         }
       }
 

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -279,7 +279,7 @@ void main() {
         ..writeAsBytesSync(encodePng(i0));
     });
 
-    test('copyResize linear smaller maintainAspect color correctness', () {
+    test('copyResize cubic smaller maintainAspect color correctness', () {
       final img =
           decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
       final i0 = copyResize(img,

--- a/test/transform/copy_resize_test.dart
+++ b/test/transform/copy_resize_test.dart
@@ -211,5 +211,28 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsBytesSync(encodePng(i0));
     });
+
+    test('copyResize average larger color correctness', () {
+      final img =
+          decodeBmp(File('test/_data/bmp/rgba24.bmp').readAsBytesSync())!;
+      final i0 = copyResize(img,
+          width: 600,
+          interpolation: Interpolation
+              .average); // 256x256 => 600x600 = 2.34375 times each side
+      expect(i0.width, equals(600));
+      expect(i0.height, equals(600));
+      for (int y = 0; y < 600; y += 12) {
+        for (int x = 0; x < 600; x += 16) {
+          expect(
+              i0.getPixel(x, y),
+              equals(
+                  img.getPixel((x / 2.34375).toInt(), (y / 2.34375).toInt())),
+              reason: 'Pixel color at ($x,$y) in resized image is not correct');
+        }
+      }
+      File('$testOutputPath/transform/copyResize_color_average_larger_1.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(encodePng(i0));
+    });
   });
 }


### PR DESCRIPTION
Intended to improve the efficiency of `copyResize` function
Test cases are added to ensure correctness in different settings:
- nearest smaller & larger
- average larger
- linear larger
- linear smaller with specific width and height and `maintainAspect` set as `true`
- cubic smaller with specific width and height and `maintainAspect` set as `true`

Fixed a bug when specifying both width and height with a different aspect ratio and set `maintainAspect` as `true` with linear/cubic interpolation in this commit
https://github.com/wahahachan/image/commit/ba2694011df932b6ef1e6cf80d8bf6bf258e5b25

If resize `test/_data/bmp/rgba24.bmp` in the repo from 256x256 to 256x128 while setting `maintainAspect` as `true`, the following is expected (nearest and average are correct):
![copyResize_cubic_good_2](https://github.com/user-attachments/assets/cf3473b8-3051-4790-aa81-889fc697f399)
![copyResize_nearest_Good](https://github.com/user-attachments/assets/203c2fa0-3b7b-43a0-84ce-f93c72e8cbaf)

But linear and cubic will produce the following:
![copyResize_cubic_smaller_error_2](https://github.com/user-attachments/assets/51b4f6cf-5f3f-4f91-a038-80bc2af920a8)
![copyResize_linear_Error](https://github.com/user-attachments/assets/d2250d9a-3153-4442-b7a6-a72098c77623)


Nearest setting is improved by around 60% by using a pre-defined pixel object and directly calling `setPixelRgba` instead of `setPixel` where a run-time type checking for image type is done. 
Note: nearest is now achieved by `toInt` which is a truncation, perhaps `round` is a better choice. 

Average setting is improved by around 40% with similar technique.

Linear setting is improved by around 40%-50% by inlineing `getPixelInterpolate`


New results given by Nearest and Average settings should be pixel-wise equivalent to the original implementation.
New results given by Linear setting **are NOT pixel-wise equivalent** to the original implementation.

This is due to the fallback mechanism in `Color getPixelLinear(num fx, num fy)` in the original implementation.
Imagine interpolating pixels on the edge of an image (size w 128 X h 128), say we want to get a linear interpolation with (127.6, 50) as input. The first argument fx is larger than the image width, there are fallbacks to avoid memory access out of bound.

```
final icc = getPixelSafe(x, y);
final icn = ny >= height ? icc : getPixelSafe(x, ny);
final inc = nx >= width ? icc : getPixelSafe(nx, y);
final inn = nx >= width || ny >= height ? icc : getPixelSafe(nx, ny);
```
Fallback are triggered twice (inc & inn), notice that `inn` is picking `icc` as backup since nx is larger/eq to width.
Eventually icc = (127, 50), icn = (127, 51), inc = (127, 50), inn = (127, 50), where 3 duplications of (127, 50) are interpolating with 1 pixel in (128, 51).

In the new implementation,  icc = (127, 50), icn = (127, 51), inc = (127, 50), inn = (127, 51). This is like doing a linear interpolation along the edge between (127, 50) and (127, 51).

This unavoidably introduces differences between the original and new implementation. I am happy to restore back to the original implementation in case there can be many other libraries that depend on this result to work.

Cubic is not improved. 
