### PR TITLE
Fix add frame on empty image

### DIFF
--- a/lib/image.dart
+++ b/lib/image.dart
@@ -112,6 +112,7 @@ export 'src/formats/gif_decoder.dart';
 export 'src/formats/gif_encoder.dart';
 export 'src/formats/ico/ico_info.dart';
 export 'src/formats/ico_decoder.dart';
+export 'src/formats/ico_encoder.dart';
 export 'src/formats/image_format.dart';
 export 'src/formats/jpeg/jpeg_adobe.dart';
 export 'src/formats/jpeg/jpeg_component.dart';

--- a/lib/src/image/image.dart
+++ b/lib/src/image/image.dart
@@ -347,7 +347,7 @@ class Image extends Iterable<Pixel> {
   Image addFrame([Image? image]) {
     image ??= Image.from(this, noAnimation: true, noPixels: true);
     image.frameIndex = frames.length;
-    if (frames.last != image) {
+    if (frames.isEmpty || frames.last != image) {
       frames.add(image);
     }
     return image;


### PR DESCRIPTION
when adding a frame on an empty image, 

```
    final icoImage = Image.empty();
    for (final iconSize in _iconSizes) {
      icoImage.addFrame(utils.createResizedImage(iconSize, image));
    }
```

the following error is returned:
️Bad state: No element

this PR fixes this.

I also added a missing export for the `IcoEncoder`.