### PR TITLE
feat: add lanczos interpolation implementation

### DIFF
--- a/lib/src/image/interpolation.dart
+++ b/lib/src/image/interpolation.dart
@@ -13,7 +13,7 @@ enum Interpolation {
   average,
 
   /// Computationally heavy and extremely slow algorithm with good results.
-  /// Slowest, highest Quality.
+  /// Slowest, provides highest quality for downscaling.
   lanczos,
   ;
 }

--- a/lib/src/image/interpolation.dart
+++ b/lib/src/image/interpolation.dart
@@ -6,9 +6,14 @@ enum Interpolation {
   /// Linearly blend between the neighboring pixels.
   linear,
 
-  /// Cubic blend between the neighboring pixels. Slowest, highest Quality.
+  /// Cubic blend between the neighboring pixels. Slow, high Quality.
   cubic,
 
   /// Average the colors of the neighboring pixels.
-  average
+  average,
+
+  /// Computationally heavy and extremely slow algorithm with good results.
+  /// Slowest, highest Quality.
+  lanczos,
+  ;
 }

--- a/lib/src/transform/copy_resize.dart
+++ b/lib/src/transform/copy_resize.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:typed_data';
 
 import '../color/color.dart';
@@ -105,116 +106,195 @@ Image copyResize(Image src,
       dst.clear(backgroundColor);
     }
 
-    if (interpolation == Interpolation.average) {
-      final srcPixel = frame.getPixelSafe(0, 0);
-      for (var y = 0; y < h; ++y) {
-        final ay1 = (y * dy).toInt();
-        var ay2 = ((y + 1) * dy).toInt();
-        if (ay2 == ay1) {
-          ay2++;
+    switch (interpolation) {
+      case Interpolation.lanczos:
+        // implementation based on https://github.com/Megakuul/image_scaler/blob/main/lib/lanczos.dart
+        final srcPixel = frame.getPixelSafe(0, 0);
+        double _kernel(double x, int a) {
+          if (x == 0) return 1;
+          if (x.abs() >= a) return 0;
+          return a * sin(pi * x) * sin(pi * x / a) / (pi * pi * x * x);
         }
+
+        final lanczosXScale = frame.width > w ? dx : 1;
+        final lanczosYScale = frame.height > h ? dy : 1;
+
+        const areaSize = 1;
+        const maxAreaDiameter = (areaSize * 2) + 1;
+
+        double iX;
+        double iY;
+
+        double tWeight;
+        final rgbStack = Uint32List(4);
+
+        double _dx;
+        double _dy;
+        double d;
+        double curWeight;
+
+        ({int x, int y}) iAreaTLAnchor, iAreaBRAnchor;
 
         for (var x = 0; x < w; ++x) {
-          final ax1 = (x * dx).toInt();
-          var ax2 = ((x + 1) * dx).toInt();
-          if (ax2 == ax1) {
-            ax2++;
-          }
+          iX = x * dx;
+          for (var y = 0; y < h; ++y) {
+            iY = y * dy;
 
-          num r = 0;
-          num g = 0;
-          num b = 0;
-          num a = 0;
-          var np = 0;
-          for (var sy = ay1; sy < ay2; ++sy) {
-            for (var sx = ax1; sx < ax2; ++sx, ++np) {
-              frame.getPixel(sx, sy, srcPixel);
-              r += srcPixel.r;
-              g += srcPixel.g;
-              b += srcPixel.b;
-              a += srcPixel.a;
+            // Top Left Area Anchor
+            iAreaTLAnchor = (
+              x: (iX - areaSize < 0 ? 0 : iX - areaSize).toInt(),
+              y: (iY - areaSize < 0 ? 0 : iY - areaSize).toInt()
+            );
+            // Bottom Right Area Anchor
+            iAreaBRAnchor = (
+              x: (iAreaTLAnchor.x + maxAreaDiameter).clamp(0, frame.width),
+              y: (iAreaTLAnchor.y + maxAreaDiameter).clamp(0, frame.height),
+            );
+
+            tWeight = 0;
+            rgbStack.fillRange(0, 3, 0);
+
+            for (var iXArea = iAreaTLAnchor.x;
+                iXArea < iAreaBRAnchor.x;
+                iXArea++) {
+              for (var iYArea = iAreaTLAnchor.y;
+                  iYArea < iAreaBRAnchor.y;
+                  iYArea++) {
+                _dx = (iXArea - iX).abs() / lanczosXScale;
+                _dy = (iYArea - iY).abs() / lanczosYScale;
+                d = sqrt(_dx * _dx + _dy * _dy);
+                curWeight = _kernel(d, areaSize);
+
+                frame.getPixel(iXArea, iYArea, srcPixel);
+                rgbStack[0] += (srcPixel.r * curWeight).round();
+                rgbStack[1] += (srcPixel.g * curWeight).round();
+                rgbStack[2] += (srcPixel.b * curWeight).round();
+                rgbStack[3] += (srcPixel.a * curWeight).round();
+
+                tWeight += curWeight;
+              }
             }
-          }
-          dst.setPixelRgba(x1 + x, y1 + y, r / np, g / np, b / np, a / np);
-        }
-      }
-    } else if (interpolation == Interpolation.nearest) {
-      if (frame.hasPalette) {
-        for (var y = 0; y < h; ++y) {
-          final y2 = (y * dy).toInt();
-          for (var x = 0; x < w; ++x) {
-            dst.setPixelIndex(
-                x1 + x, y1 + y, frame.getPixelIndex(scaleX[x], y2));
+
+            dst.setPixelRgba(
+              x1 + x,
+              y1 + y,
+              (rgbStack[0] / tWeight).clamp(0, 255).round(),
+              (rgbStack[1] / tWeight).clamp(0, 255).round(),
+              (rgbStack[2] / tWeight).clamp(0, 255).round(),
+              (rgbStack[3] / tWeight).clamp(0, 255).round(),
+            );
           }
         }
-      } else {
+      case Interpolation.average:
         final srcPixel = frame.getPixelSafe(0, 0);
         for (var y = 0; y < h; ++y) {
+          final ay1 = (y * dy).toInt();
+          var ay2 = ((y + 1) * dy).toInt();
+          if (ay2 == ay1) {
+            ay2++;
+          }
+
           for (var x = 0; x < w; ++x) {
-            frame.getPixel(scaleX[x], scaleY[y], srcPixel);
-            dst.setPixelRgba(
-                x1 + x, y1 + y, srcPixel.r, srcPixel.g, srcPixel.b, srcPixel.a);
-            // Not calling setPixel which triggers runtime type checking
-            // mainly for hasPalette routine. Palette images are treated in
-            // the above if-else block.
-            //dst.setPixel(x1 + x, y1 + y, frame.getPixel(scaleX[x], y2));
+            final ax1 = (x * dx).toInt();
+            var ax2 = ((x + 1) * dx).toInt();
+            if (ax2 == ax1) {
+              ax2++;
+            }
+
+            num r = 0;
+            num g = 0;
+            num b = 0;
+            num a = 0;
+            var np = 0;
+            for (var sy = ay1; sy < ay2; ++sy) {
+              for (var sx = ax1; sx < ax2; ++sx, ++np) {
+                frame.getPixel(sx, sy, srcPixel);
+                r += srcPixel.r;
+                g += srcPixel.g;
+                b += srcPixel.b;
+                a += srcPixel.a;
+              }
+            }
+            dst.setPixelRgba(x1 + x, y1 + y, r / np, g / np, b / np, a / np);
           }
         }
-      }
-    } else if (interpolation == Interpolation.linear) {
-      // 4 predefined pixel object for 4 vertices
-      final icc = frame.getPixelSafe(0, 0);
-      final icn = frame.getPixelSafe(0, 0);
-      final inc = frame.getPixelSafe(0, 0);
-      final inn = frame.getPixelSafe(0, 0);
-
-      num linear(num icc, num inc, num icn, num inn, num kx, num ky) =>
-          icc +
-          kx * (inc - icc + ky * (icc + inn - icn - inc)) +
-          ky * (icn - icc);
-
-      // Copy the pixels from this image to the new image.
-      for (var y = 0; y < h; ++y) {
-        final sy2 = y * dy;
-        for (var x = 0; x < w; ++x) {
-          final sx2 = x * dx;
-          final fx = sx2.clamp(0, frame.width - 1);
-          final fy = sy2.clamp(0, frame.height - 1);
-          final ix = fx.toInt();
-          final iy = fy.toInt();
-          final kx = fx - ix;
-          final ky = fy - iy;
-          final nx = (ix + 1).clamp(0, frame.width - 1);
-          final ny = (iy + 1).clamp(0, frame.height - 1);
-
-          frame
-            ..getPixel(ix, iy, icc)
-            ..getPixel(ix, ny, icn)
-            ..getPixel(nx, iy, inc)
-            ..getPixel(nx, ny, inn);
-
-          dst.setPixelRgba(
-              x1 + x,
-              y1 + y,
-              linear(icc.r, inc.r, icn.r, inn.r, kx, ky),
-              linear(icc.g, inc.g, icn.g, inn.g, kx, ky),
-              linear(icc.b, inc.b, icn.b, inn.b, kx, ky),
-              linear(icc.a, inc.a, icn.a, inn.a, kx, ky));
+      case Interpolation.nearest:
+        if (frame.hasPalette) {
+          for (var y = 0; y < h; ++y) {
+            final y2 = (y * dy).toInt();
+            for (var x = 0; x < w; ++x) {
+              dst.setPixelIndex(
+                  x1 + x, y1 + y, frame.getPixelIndex(scaleX[x], y2));
+            }
+          }
+        } else {
+          final srcPixel = frame.getPixelSafe(0, 0);
+          for (var y = 0; y < h; ++y) {
+            for (var x = 0; x < w; ++x) {
+              frame.getPixel(scaleX[x], scaleY[y], srcPixel);
+              dst.setPixelRgba(x1 + x, y1 + y, srcPixel.r, srcPixel.g,
+                  srcPixel.b, srcPixel.a);
+              // Not calling setPixel which triggers runtime type checking
+              // mainly for hasPalette routine. Palette images are treated in
+              // the above if-else block.
+              //dst.setPixel(x1 + x, y1 + y, frame.getPixel(scaleX[x], y2));
+            }
+          }
         }
-      }
-    } else {
-      // Copy the pixels from this image to the new image.
-      for (var y = 0; y < h; ++y) {
-        final sy2 = y * dy;
-        for (var x = 0; x < w; ++x) {
-          final sx2 = x * dx;
-          dst.setPixel(
-              x1 + x,
-              y1 + y,
-              frame.getPixelInterpolate(sx2, sy2,
-                  interpolation: interpolation));
+      case Interpolation.linear:
+        // 4 predefined pixel object for 4 vertices
+        final icc = frame.getPixelSafe(0, 0);
+        final icn = frame.getPixelSafe(0, 0);
+        final inc = frame.getPixelSafe(0, 0);
+        final inn = frame.getPixelSafe(0, 0);
+
+        num linear(num icc, num inc, num icn, num inn, num kx, num ky) =>
+            icc +
+            kx * (inc - icc + ky * (icc + inn - icn - inc)) +
+            ky * (icn - icc);
+
+        // Copy the pixels from this image to the new image.
+        for (var y = 0; y < h; ++y) {
+          final sy2 = y * dy;
+          for (var x = 0; x < w; ++x) {
+            final sx2 = x * dx;
+            final fx = sx2.clamp(0, frame.width - 1);
+            final fy = sy2.clamp(0, frame.height - 1);
+            final ix = fx.toInt();
+            final iy = fy.toInt();
+            final kx = fx - ix;
+            final ky = fy - iy;
+            final nx = (ix + 1).clamp(0, frame.width - 1);
+            final ny = (iy + 1).clamp(0, frame.height - 1);
+
+            frame
+              ..getPixel(ix, iy, icc)
+              ..getPixel(ix, ny, icn)
+              ..getPixel(nx, iy, inc)
+              ..getPixel(nx, ny, inn);
+
+            dst.setPixelRgba(
+                x1 + x,
+                y1 + y,
+                linear(icc.r, inc.r, icn.r, inn.r, kx, ky),
+                linear(icc.g, inc.g, icn.g, inn.g, kx, ky),
+                linear(icc.b, inc.b, icn.b, inn.b, kx, ky),
+                linear(icc.a, inc.a, icn.a, inn.a, kx, ky));
+          }
         }
-      }
+      case Interpolation.cubic:
+        // Copy the pixels from this image to the new image.
+        for (var y = 0; y < h; ++y) {
+          final sy2 = y * dy;
+          for (var x = 0; x < w; ++x) {
+            final sx2 = x * dx;
+            dst.setPixel(
+                x1 + x,
+                y1 + y,
+                frame.getPixelInterpolate(sx2, sy2,
+                    interpolation: interpolation));
+          }
+        }
     }
   }
 

--- a/lib/src/transform/resize.dart
+++ b/lib/src/transform/resize.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:typed_data';
 
 import '../color/color.dart';
@@ -103,90 +104,169 @@ Image resize(Image src,
     if (maintainAspect && backgroundColor != null) {
       dst.clear(backgroundColor);
     }
-
-    if (interpolation == Interpolation.average) {
-      for (var y = 0; y < h; ++y) {
-        final ay1 = (y * dy).toInt();
-        var ay2 = ((y + 1) * dy).toInt();
-        if (ay2 == ay1) {
-          ay2++;
+    switch (interpolation) {
+      case Interpolation.lanczos:
+        // implementation based on https://github.com/Megakuul/image_scaler/blob/main/lib/lanczos.dart
+        double _kernel(double x, int a) {
+          if (x == 0) return 1;
+          if (x.abs() >= a) return 0;
+          return a * sin(pi * x) * sin(pi * x / a) / (pi * pi * x * x);
         }
 
+        final lanczosXScale = frame.width > w ? dx : 1;
+        final lanczosYScale = frame.height > h ? dy : 1;
+
+        const areaSize = 1;
+        const maxAreaDiameter = (areaSize * 2) + 1;
+
+        double iX;
+        double iY;
+
+        double tWeight;
+        final rgbStack = Uint32List(4);
+
+        double _dx;
+        double _dy;
+        double d;
+        double curWeight;
+
+        ({int x, int y}) iAreaTLAnchor, iAreaBRAnchor;
+
         for (var x = 0; x < w; ++x) {
-          final ax1 = (x * dx).toInt();
-          var ax2 = ((x + 1) * dx).toInt();
-          if (ax2 == ax1) {
-            ax2++;
+          iX = x * dx;
+          for (var y = 0; y < h; ++y) {
+            iY = y * dy;
+
+            // Top Left Area Anchor
+            iAreaTLAnchor = (
+              x: (iX - areaSize < 0 ? 0 : iX - areaSize).toInt(),
+              y: (iY - areaSize < 0 ? 0 : iY - areaSize).toInt()
+            );
+            // Bottom Right Area Anchor
+            iAreaBRAnchor = (
+              x: (iAreaTLAnchor.x + maxAreaDiameter).clamp(0, frame.width),
+              y: (iAreaTLAnchor.y + maxAreaDiameter).clamp(0, frame.height),
+            );
+
+            tWeight = 0;
+            rgbStack.fillRange(0, 3, 0);
+
+            for (var iXArea = iAreaTLAnchor.x;
+                iXArea < iAreaBRAnchor.x;
+                iXArea++) {
+              for (var iYArea = iAreaTLAnchor.y;
+                  iYArea < iAreaBRAnchor.y;
+                  iYArea++) {
+                _dx = (iXArea - iX).abs() / lanczosXScale;
+                _dy = (iYArea - iY).abs() / lanczosYScale;
+                d = sqrt(_dx * _dx + _dy * _dy);
+                curWeight = _kernel(d, areaSize);
+
+                final px = frame.getPixel(iXArea, iYArea);
+                rgbStack[0] += (px.r * curWeight).round();
+                rgbStack[1] += (px.g * curWeight).round();
+                rgbStack[2] += (px.b * curWeight).round();
+                rgbStack[3] += (px.a * curWeight).round();
+
+                tWeight += curWeight;
+              }
+            }
+
+            final c = dst.getColor(
+              (rgbStack[0] / tWeight).clamp(0, 255).round(),
+              (rgbStack[1] / tWeight).clamp(0, 255).round(),
+              (rgbStack[2] / tWeight).clamp(0, 255).round(),
+              (rgbStack[3] / tWeight).clamp(0, 255).round(),
+            );
+
+            dst.data!.width = width;
+            dst.data!.height = height;
+            dst.setPixel(x1 + x, y1 + y, c);
+            dst.data!.width = origWidth;
+            dst.data!.height = origHeight;
+          }
+        }
+      case Interpolation.average:
+        for (var y = 0; y < h; ++y) {
+          final ay1 = (y * dy).toInt();
+          var ay2 = ((y + 1) * dy).toInt();
+          if (ay2 == ay1) {
+            ay2++;
           }
 
-          num r = 0;
-          num g = 0;
-          num b = 0;
-          num a = 0;
-          var np = 0;
-          for (var sy = ay1; sy < ay2; ++sy) {
-            for (var sx = ax1; sx < ax2; ++sx, ++np) {
-              final s = frame.getPixel(sx, sy);
-              r += s.r;
-              g += s.g;
-              b += s.b;
-              a += s.a;
+          for (var x = 0; x < w; ++x) {
+            final ax1 = (x * dx).toInt();
+            var ax2 = ((x + 1) * dx).toInt();
+            if (ax2 == ax1) {
+              ax2++;
+            }
+
+            num r = 0;
+            num g = 0;
+            num b = 0;
+            num a = 0;
+            var np = 0;
+            for (var sy = ay1; sy < ay2; ++sy) {
+              for (var sx = ax1; sx < ax2; ++sx, ++np) {
+                final s = frame.getPixel(sx, sy);
+                r += s.r;
+                g += s.g;
+                b += s.b;
+                a += s.a;
+              }
+            }
+            final c = dst.getColor(r / np, g / np, b / np, a / np);
+
+            dst.data!.width = width;
+            dst.data!.height = height;
+            dst.setPixel(x1 + x, y1 + y, c);
+            dst.data!.width = origWidth;
+            dst.data!.height = origHeight;
+          }
+        }
+      case Interpolation.nearest:
+        if (frame.hasPalette) {
+          for (var y = 0; y < h; ++y) {
+            final y2 = (y * dy).toInt();
+            for (var x = 0; x < w; ++x) {
+              final p = frame.getPixelIndex(scaleX[x], y2);
+              dst.data!.width = width;
+              dst.data!.height = height;
+              dst.setPixelIndex(x1 + x, y1 + y, p);
+              dst.data!.width = origWidth;
+              dst.data!.height = origHeight;
             }
           }
-          final c = dst.getColor(r / np, g / np, b / np, a / np);
-
-          dst.data!.width = width;
-          dst.data!.height = height;
-          dst.setPixel(x1 + x, y1 + y, c);
-          dst.data!.width = origWidth;
-          dst.data!.height = origHeight;
+        } else {
+          for (var y = 0; y < h; ++y) {
+            final y2 = (y * dy).toInt();
+            for (var x = 0; x < w; ++x) {
+              final p = frame.getPixel(scaleX[x], y2);
+              dst.data!.width = width;
+              dst.data!.height = height;
+              dst.setPixel(x1 + x, y1 + y, p);
+              dst.data!.width = origWidth;
+              dst.data!.height = origHeight;
+            }
+          }
         }
-      }
-    } else if (interpolation == Interpolation.nearest) {
-      if (frame.hasPalette) {
+      case Interpolation.cubic:
+      case Interpolation.linear:
+        // Copy the pixels from this image to the new image.
         for (var y = 0; y < h; ++y) {
-          final y2 = (y * dy).toInt();
+          final sy2 = y * dy;
           for (var x = 0; x < w; ++x) {
-            final p = frame.getPixelIndex(scaleX[x], y2);
+            final sx2 = x * dx;
+            final p = frame.getPixelInterpolate(x1 + sx2, y1 + sy2,
+                interpolation: interpolation);
             dst.data!.width = width;
             dst.data!.height = height;
-            dst.setPixelIndex(x1 + x, y1 + y, p);
+            dst.setPixel(x, y, p);
             dst.data!.width = origWidth;
             dst.data!.height = origHeight;
           }
         }
-      } else {
-        for (var y = 0; y < h; ++y) {
-          final y2 = (y * dy).toInt();
-          for (var x = 0; x < w; ++x) {
-            final p = frame.getPixel(scaleX[x], y2);
-            dst.data!.width = width;
-            dst.data!.height = height;
-            dst.setPixel(x1 + x, y1 + y, p);
-            dst.data!.width = origWidth;
-            dst.data!.height = origHeight;
-          }
-        }
-      }
-    } else {
-      // Copy the pixels from this image to the new image.
-      for (var y = 0; y < h; ++y) {
-        final sy2 = y * dy;
-        for (var x = 0; x < w; ++x) {
-          final sx2 = x * dx;
-          final p = frame.getPixelInterpolate(x1 + sx2, y1 + sy2,
-              interpolation: interpolation);
-          dst.data!.width = width;
-          dst.data!.height = height;
-          dst.setPixel(x, y, p);
-          dst.data!.width = origWidth;
-          dst.data!.height = origHeight;
-        }
-      }
     }
-
-    dst.data!.width = width;
-    dst.data!.height = height;
   }
 
   return src;


### PR DESCRIPTION
based on MIT licensed https://github.com/Megakuul/image_scaler/blob/main/lib/lanczos.dart

resize works good, but I'm not sure if that's correct implementation for `getPixelLanczos`
it produces good results for down sampling, but upscaling is not good comparing to resize (because of missing precise scale factor?)
i've compared it by using fall back (last else before) instead of dedicated switch case.

upd: some issues with alpha processing