### PR TITLE
fix error 'package:image/src/formats/ico_encoder.dart' is unnecessary

### DIFF
--- a/test/formats/ico_test.dart
+++ b/test/formats/ico_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:image/image.dart';
-import 'package:image/src/formats/ico_encoder.dart';
 import 'package:test/test.dart';
 
 import '../_test_util.dart';


### PR DESCRIPTION
I made a correction since you seemed busy.

You can ignore this pr. :)