### PR TITLE
Allow BlendMode to be used in the majority of the draw* methods and some fill* ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pubspec.lock
 .packages
 .DS_Store
 _out/
+build

--- a/lib/src/command/command.dart
+++ b/lib/src/command/command.dart
@@ -401,6 +401,7 @@ class Command {
       required int x,
       required int y,
       Color? color,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = DrawCharCmd(subCommand, char,
@@ -408,6 +409,7 @@ class Command {
         x: x,
         y: y,
         color: color,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -418,6 +420,7 @@ class Command {
       required int radius,
       required Color color,
       bool antialias = false,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = DrawCircleCmd(subCommand,
@@ -426,6 +429,7 @@ class Command {
         radius: radius,
         color: color,
         antialias: antialias,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -468,6 +472,7 @@ class Command {
       required Color color,
       bool antialias = false,
       num thickness = 1,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = DrawLineCmd(subCommand,
@@ -478,6 +483,7 @@ class Command {
         color: color,
         antialias: antialias,
         thickness: thickness,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -497,10 +503,15 @@ class Command {
   void drawPolygon(
       {required List<Point> vertices,
       required Color color,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = DrawPolygonCmd(subCommand,
-        vertices: vertices, color: color, mask: mask, maskChannel: maskChannel);
+        vertices: vertices,
+        color: color,
+        blend: blend,
+        mask: mask,
+        maskChannel: maskChannel);
   }
 
   void drawRect(
@@ -511,6 +522,7 @@ class Command {
       required Color color,
       num radius = 0,
       num thickness = 1,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = DrawRectCmd(subCommand,
@@ -521,6 +533,7 @@ class Command {
         color: color,
         radius: radius,
         thickness: thickness,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -532,6 +545,7 @@ class Command {
       Color? color,
       bool wrap = false,
       bool rightJustify = false,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = DrawStringCmd(subCommand, string,
@@ -541,6 +555,7 @@ class Command {
         color: color,
         wrap: wrap,
         rightJustify: rightJustify,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -559,6 +574,7 @@ class Command {
       required int radius,
       required Color color,
       bool antialias = false,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = FillCircleCmd(subCommand,
@@ -567,6 +583,7 @@ class Command {
         radius: radius,
         color: color,
         antialias: antialias,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -592,10 +609,15 @@ class Command {
   void fillPolygon(
       {required List<Point> vertices,
       required Color color,
+      BlendMode blend = BlendMode.alpha,
       Command? mask,
       Channel maskChannel = Channel.luminance}) {
     subCommand = FillPolygonCmd(subCommand,
-        vertices: vertices, color: color, mask: mask, maskChannel: maskChannel);
+        vertices: vertices,
+        color: color,
+        blend: blend,
+        mask: mask,
+        maskChannel: maskChannel);
   }
 
   void fillRect(

--- a/lib/src/command/draw/draw_char_cmd.dart
+++ b/lib/src/command/draw/draw_char_cmd.dart
@@ -1,8 +1,4 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/draw_char.dart';
-import '../../font/bitmap_font.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class DrawCharCmd extends Command {
   BitmapFont font;
@@ -10,6 +6,7 @@ class DrawCharCmd extends Command {
   int y;
   String char;
   Color? color;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
@@ -18,6 +15,7 @@ class DrawCharCmd extends Command {
       required this.x,
       required this.y,
       this.color,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -32,6 +30,7 @@ class DrawCharCmd extends Command {
             x: x,
             y: y,
             color: color,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/draw_char_cmd.dart
+++ b/lib/src/command/draw/draw_char_cmd.dart
@@ -1,4 +1,9 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/draw_char.dart';
+import '../../font/bitmap_font.dart';
+import '../command.dart';
 
 class DrawCharCmd extends Command {
   BitmapFont font;

--- a/lib/src/command/draw/draw_circle_cmd.dart
+++ b/lib/src/command/draw/draw_circle_cmd.dart
@@ -1,7 +1,4 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/draw_circle.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class DrawCircleCmd extends Command {
   int x;
@@ -9,6 +6,7 @@ class DrawCircleCmd extends Command {
   int radius;
   Color color;
   bool antialias;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
@@ -18,6 +16,7 @@ class DrawCircleCmd extends Command {
       required this.radius,
       required this.color,
       this.antialias = false,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -33,6 +32,7 @@ class DrawCircleCmd extends Command {
             radius: radius,
             color: color,
             antialias: antialias,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/draw_circle_cmd.dart
+++ b/lib/src/command/draw/draw_circle_cmd.dart
@@ -1,4 +1,8 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/draw_circle.dart';
+import '../command.dart';
 
 class DrawCircleCmd extends Command {
   int x;

--- a/lib/src/command/draw/draw_line_cmd.dart
+++ b/lib/src/command/draw/draw_line_cmd.dart
@@ -1,4 +1,8 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/draw_line.dart';
+import '../command.dart';
 
 class DrawLineCmd extends Command {
   int x1;

--- a/lib/src/command/draw/draw_line_cmd.dart
+++ b/lib/src/command/draw/draw_line_cmd.dart
@@ -1,7 +1,4 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/draw_line.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class DrawLineCmd extends Command {
   int x1;
@@ -11,6 +8,7 @@ class DrawLineCmd extends Command {
   Color color;
   bool antialias;
   num thickness;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
@@ -22,6 +20,7 @@ class DrawLineCmd extends Command {
       required this.color,
       this.antialias = false,
       this.thickness = 1,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -39,6 +38,7 @@ class DrawLineCmd extends Command {
             color: color,
             antialias: antialias,
             thickness: thickness,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/draw_polygon_cmd.dart
+++ b/lib/src/command/draw/draw_polygon_cmd.dart
@@ -1,18 +1,16 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/draw_polygon.dart';
-import '../../util/point.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class DrawPolygonCmd extends Command {
   List<Point> vertices;
   Color color;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
   DrawPolygonCmd(Command? input,
       {required this.vertices,
       required this.color,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -25,6 +23,7 @@ class DrawPolygonCmd extends Command {
         ? drawPolygon(img,
             vertices: vertices,
             color: color,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/draw_polygon_cmd.dart
+++ b/lib/src/command/draw/draw_polygon_cmd.dart
@@ -1,4 +1,9 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/draw_polygon.dart';
+import '../../util/point.dart';
+import '../command.dart';
 
 class DrawPolygonCmd extends Command {
   List<Point> vertices;

--- a/lib/src/command/draw/draw_rect_cmd.dart
+++ b/lib/src/command/draw/draw_rect_cmd.dart
@@ -1,7 +1,4 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/draw_rect.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class DrawRectCmd extends Command {
   int x1;
@@ -11,6 +8,7 @@ class DrawRectCmd extends Command {
   Color color;
   num radius;
   num thickness;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
@@ -22,6 +20,7 @@ class DrawRectCmd extends Command {
       required this.color,
       this.thickness = 1,
       this.radius = 0,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -39,6 +38,7 @@ class DrawRectCmd extends Command {
             color: color,
             thickness: thickness,
             radius: radius,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/draw_rect_cmd.dart
+++ b/lib/src/command/draw/draw_rect_cmd.dart
@@ -1,4 +1,8 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/draw_rect.dart';
+import '../command.dart';
 
 class DrawRectCmd extends Command {
   int x1;

--- a/lib/src/command/draw/draw_string_cmd.dart
+++ b/lib/src/command/draw/draw_string_cmd.dart
@@ -1,8 +1,4 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/draw_string.dart';
-import '../../font/bitmap_font.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class DrawStringCmd extends Command {
   BitmapFont font;
@@ -12,6 +8,7 @@ class DrawStringCmd extends Command {
   bool rightJustify;
   bool wrap;
   Color? color;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
@@ -22,6 +19,7 @@ class DrawStringCmd extends Command {
       this.color,
       this.wrap = false,
       this.rightJustify = false,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -38,6 +36,7 @@ class DrawStringCmd extends Command {
             color: color,
             rightJustify: rightJustify,
             wrap: wrap,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/draw_string_cmd.dart
+++ b/lib/src/command/draw/draw_string_cmd.dart
@@ -1,4 +1,9 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/draw_string.dart';
+import '../../font/bitmap_font.dart';
+import '../command.dart';
 
 class DrawStringCmd extends Command {
   BitmapFont font;

--- a/lib/src/command/draw/fill_circle_cmd.dart
+++ b/lib/src/command/draw/fill_circle_cmd.dart
@@ -1,7 +1,4 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/fill_circle.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class FillCircleCmd extends Command {
   int x;
@@ -9,6 +6,7 @@ class FillCircleCmd extends Command {
   int radius;
   Color color;
   bool antialias;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
@@ -18,6 +16,7 @@ class FillCircleCmd extends Command {
       required this.radius,
       required this.color,
       this.antialias = false,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -33,6 +32,7 @@ class FillCircleCmd extends Command {
             radius: radius,
             color: color,
             antialias: antialias,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/command/draw/fill_circle_cmd.dart
+++ b/lib/src/command/draw/fill_circle_cmd.dart
@@ -1,4 +1,8 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/fill_circle.dart';
+import '../command.dart';
 
 class FillCircleCmd extends Command {
   int x;

--- a/lib/src/command/draw/fill_polygon_cmd.dart
+++ b/lib/src/command/draw/fill_polygon_cmd.dart
@@ -1,4 +1,9 @@
-import '../../../image.dart';
+import '../../color/channel.dart';
+import '../../color/color.dart';
+import '../../draw/blend_mode.dart';
+import '../../draw/fill_polygon.dart';
+import '../../util/point.dart';
+import '../command.dart';
 
 class FillPolygonCmd extends Command {
   List<Point> vertices;

--- a/lib/src/command/draw/fill_polygon_cmd.dart
+++ b/lib/src/command/draw/fill_polygon_cmd.dart
@@ -1,18 +1,16 @@
-import '../../color/channel.dart';
-import '../../color/color.dart';
-import '../../draw/fill_polygon.dart';
-import '../../util/point.dart';
-import '../command.dart';
+import '../../../image.dart';
 
 class FillPolygonCmd extends Command {
   List<Point> vertices;
   Color color;
+  BlendMode blend;
   Command? mask;
   Channel maskChannel;
 
   FillPolygonCmd(Command? input,
       {required this.vertices,
       required this.color,
+      this.blend = BlendMode.alpha,
       this.mask,
       this.maskChannel = Channel.luminance})
       : super(input);
@@ -25,6 +23,7 @@ class FillPolygonCmd extends Command {
         ? fillPolygon(img,
             vertices: vertices,
             color: color,
+            blend: blend,
             mask: maskImg,
             maskChannel: maskChannel)
         : null;

--- a/lib/src/draw/_draw_antialias_circle.dart
+++ b/lib/src/draw/_draw_antialias_circle.dart
@@ -1,10 +1,7 @@
 import 'dart:math';
 
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../image/image.dart';
+import '../../image.dart';
 import '../util/math_util.dart';
-import 'draw_pixel.dart';
 
 const topLeftQuadrant = 1;
 const topRightQuadrant = 2;
@@ -21,31 +18,32 @@ Image drawAntialiasCircle(Image image,
     required int radius,
     required Color color,
     int quadrants = allQuadrants,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   void drawPixel4(int x, int y, int dx, int dy, num alpha) {
     // bottom right
     if (quadrants & bottomRightQuadrant != 0) {
       drawPixel(image, x + dx, y + dy, color,
-          alpha: alpha, mask: mask, maskChannel: maskChannel);
+          alpha: alpha, blend: blend, mask: mask, maskChannel: maskChannel);
     }
 
     // bottom left
     if (quadrants & bottomLeftQuadrant != 0) {
       drawPixel(image, x - dx, y + dy, color,
-          alpha: alpha, mask: mask, maskChannel: maskChannel);
+          alpha: alpha, blend: blend, mask: mask, maskChannel: maskChannel);
     }
 
     // upper right
     if (quadrants & topRightQuadrant != 0) {
       drawPixel(image, x + dx, y - dy, color,
-          alpha: alpha, mask: mask, maskChannel: maskChannel);
+          alpha: alpha, blend: blend, mask: mask, maskChannel: maskChannel);
     }
 
     // upper left
     if (quadrants & topLeftQuadrant != 0) {
       drawPixel(image, x - dx, y - dy, color,
-          alpha: alpha, mask: mask, maskChannel: maskChannel);
+          alpha: alpha, blend: blend, mask: mask, maskChannel: maskChannel);
     }
   }
 

--- a/lib/src/draw/_draw_antialias_circle.dart
+++ b/lib/src/draw/_draw_antialias_circle.dart
@@ -1,7 +1,11 @@
 import 'dart:math';
 
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../image/image.dart';
 import '../util/math_util.dart';
+import 'blend_mode.dart';
+import 'draw_pixel.dart';
 
 const topLeftQuadrant = 1;
 const topRightQuadrant = 2;

--- a/lib/src/draw/draw_char.dart
+++ b/lib/src/draw/draw_char.dart
@@ -1,8 +1,4 @@
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../font/bitmap_font.dart';
-import '../image/image.dart';
-import 'draw_pixel.dart';
+import '../../image.dart';
 
 /// Draw a single character from [char] horizontally into [image] at position
 /// [x],[y] with the given [color].
@@ -11,6 +7,7 @@ Image drawChar(Image image, String char,
     required int x,
     required int y,
     Color? color,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   final c = char.codeUnits[0];
@@ -28,10 +25,13 @@ Image drawChar(Image image, String char,
       final cp = cIter.current;
       if (color != null) {
         drawPixel(image, xi, yi, color,
-            alpha: cp.aNormalized, mask: mask, maskChannel: maskChannel);
+            alpha: cp.aNormalized,
+            blend: blend,
+            mask: mask,
+            maskChannel: maskChannel);
       } else {
         drawPixel(image, xi, yi, cIter.current,
-            mask: mask, maskChannel: maskChannel);
+            blend: blend, mask: mask, maskChannel: maskChannel);
       }
     }
   }

--- a/lib/src/draw/draw_char.dart
+++ b/lib/src/draw/draw_char.dart
@@ -1,4 +1,9 @@
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../font/bitmap_font.dart';
+import '../image/image.dart';
+import 'blend_mode.dart';
+import 'draw_pixel.dart';
 
 /// Draw a single character from [char] horizontally into [image] at position
 /// [x],[y] with the given [color].

--- a/lib/src/draw/draw_circle.dart
+++ b/lib/src/draw/draw_circle.dart
@@ -1,9 +1,6 @@
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../image/image.dart';
+import '../../image.dart';
 import '_calculate_circumference.dart';
 import '_draw_antialias_circle.dart';
-import 'draw_pixel.dart';
 
 /// Draw a circle into the [image] with a center of [x],[y] and
 /// the given [radius] and [color].
@@ -13,6 +10,7 @@ Image drawCircle(Image image,
     required int radius,
     required Color color,
     bool antialias = false,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   if (antialias) {
@@ -21,13 +19,15 @@ Image drawCircle(Image image,
         y: y,
         radius: radius,
         color: color,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
 
   final points = calculateCircumference(image, x, y, radius);
   for (final pt in points) {
-    drawPixel(image, pt.xi, pt.yi, color, mask: mask, maskChannel: maskChannel);
+    drawPixel(image, pt.xi, pt.yi, color,
+        blend: blend, mask: mask, maskChannel: maskChannel);
   }
   return image;
 }

--- a/lib/src/draw/draw_circle.dart
+++ b/lib/src/draw/draw_circle.dart
@@ -1,6 +1,10 @@
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../image/image.dart';
 import '_calculate_circumference.dart';
 import '_draw_antialias_circle.dart';
+import 'blend_mode.dart';
+import 'draw_pixel.dart';
 
 /// Draw a circle into the [image] with a center of [x],[y] and
 /// the given [radius] and [color].

--- a/lib/src/draw/draw_line.dart
+++ b/lib/src/draw/draw_line.dart
@@ -1,11 +1,6 @@
 import 'dart:math';
 
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../image/image.dart';
-import '../util/clip_line.dart';
-import 'draw_pixel.dart';
-import 'fill_circle.dart';
+import '../../image.dart';
 
 /// Draw a line into [image].
 ///
@@ -19,6 +14,7 @@ Image drawLine(Image image,
     required Color color,
     bool antialias = false,
     num thickness = 1,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   final line = [x1, y1, x2, y2];
@@ -39,12 +35,14 @@ Image drawLine(Image image,
   // Drawing a single point.
   if (dx == 0 && dy == 0) {
     thickness == 1
-        ? drawPixel(image, x1, y1, color, mask: mask, maskChannel: maskChannel)
+        ? drawPixel(image, x1, y1, color,
+            blend: blend, mask: mask, maskChannel: maskChannel)
         : fillCircle(image,
             x: x1,
             y: y1,
             radius: radius,
             color: color,
+            blend: blend,
             mask: mask,
             maskChannel: maskChannel);
     return image;
@@ -55,22 +53,24 @@ Image drawLine(Image image,
     if (dy < 0) {
       for (var y = y2; y <= y1; ++y) {
         if (thickness <= 1) {
-          drawPixel(image, x1, y, color, mask: mask, maskChannel: maskChannel);
+          drawPixel(image, x1, y, color,
+              blend: blend, mask: mask, maskChannel: maskChannel);
         } else {
           for (var i = 0; i < thickness; i++) {
             drawPixel(image, x1 - radius + i, y, color,
-                mask: mask, maskChannel: maskChannel);
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       }
     } else {
       for (var y = y1; y <= y2; ++y) {
         if (thickness <= 1) {
-          drawPixel(image, x1, y, color, mask: mask, maskChannel: maskChannel);
+          drawPixel(image, x1, y, color,
+              blend: blend, mask: mask, maskChannel: maskChannel);
         } else {
           for (var i = 0; i < thickness; i++) {
             drawPixel(image, x1 - radius + i, y, color,
-                mask: mask, maskChannel: maskChannel);
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       }
@@ -80,22 +80,24 @@ Image drawLine(Image image,
     if (dx < 0) {
       for (var x = x2; x <= x1; ++x) {
         if (thickness <= 1) {
-          drawPixel(image, x, y1, color, mask: mask, maskChannel: maskChannel);
+          drawPixel(image, x, y1, color,
+              blend: blend, mask: mask, maskChannel: maskChannel);
         } else {
           for (var i = 0; i < thickness; i++) {
             drawPixel(image, x, y1 - radius + i, color,
-                mask: mask, maskChannel: maskChannel);
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       }
     } else {
       for (var x = x1; x <= x2; ++x) {
         if (thickness <= 1) {
-          drawPixel(image, x, y1, color, mask: mask, maskChannel: maskChannel);
+          drawPixel(image, x, y1, color,
+              blend: blend, mask: mask, maskChannel: maskChannel);
         } else {
           for (var i = 0; i < thickness; i++) {
             drawPixel(image, x, y1 - radius + i, color,
-                mask: mask, maskChannel: maskChannel);
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       }
@@ -145,7 +147,8 @@ Image drawLine(Image image,
       // Set up line thickness
       var wstart = (y - wid / 2).toInt();
       for (var w = wstart; w < wstart + wid; w++) {
-        drawPixel(image, x, w, color, mask: mask, maskChannel: maskChannel);
+        drawPixel(image, x, w, color,
+            blend: blend, mask: mask, maskChannel: maskChannel);
       }
 
       if (((y2 - y1) * ydirflag) > 0) {
@@ -159,7 +162,8 @@ Image drawLine(Image image,
           }
           wstart = (y - wid / 2).toInt();
           for (var w = wstart; w < wstart + wid; w++) {
-            drawPixel(image, x, w, color, mask: mask, maskChannel: maskChannel);
+            drawPixel(image, x, w, color,
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       } else {
@@ -173,7 +177,8 @@ Image drawLine(Image image,
           }
           wstart = (y - wid / 2).toInt();
           for (var w = wstart; w < wstart + wid; w++) {
-            drawPixel(image, x, w, color, mask: mask, maskChannel: maskChannel);
+            drawPixel(image, x, w, color,
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       }
@@ -211,7 +216,8 @@ Image drawLine(Image image,
       // Set up line thickness
       var wstart = (x - wid / 2).toInt();
       for (var w = wstart; w < wstart + wid; w++) {
-        drawPixel(image, w, y, color, mask: mask, maskChannel: maskChannel);
+        drawPixel(image, w, y, color,
+            blend: blend, mask: mask, maskChannel: maskChannel);
       }
 
       if (((x2 - x1) * xdirflag) > 0) {
@@ -225,7 +231,8 @@ Image drawLine(Image image,
           }
           wstart = (x - wid / 2).toInt();
           for (var w = wstart; w < wstart + wid; w++) {
-            drawPixel(image, w, y, color, mask: mask, maskChannel: maskChannel);
+            drawPixel(image, w, y, color,
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       } else {
@@ -239,7 +246,8 @@ Image drawLine(Image image,
           }
           wstart = (x - wid / 2).toInt();
           for (var w = wstart; w < wstart + wid; w++) {
-            drawPixel(image, w, y, color, mask: mask, maskChannel: maskChannel);
+            drawPixel(image, w, y, color,
+                blend: blend, mask: mask, maskChannel: maskChannel);
           }
         }
       }
@@ -250,7 +258,15 @@ Image drawLine(Image image,
 
   // Antialias Line
   if (thickness == 1) {
-    return _drawLineWu(image, x1: x1, y1: y1, x2: x2, y2: y2, color: color);
+    return _drawLineWu(
+      image,
+      x1: x1,
+      y1: y1,
+      x2: x2,
+      y2: y2,
+      color: color,
+      blend: blend,
+    );
   }
 
   final ag = (dy.abs() < dx.abs()) ? cos(atan2(dy, dx)) : sin(atan2(dy, dx));
@@ -286,11 +302,13 @@ Image drawLine(Image image,
       for (var w = wstart; w < wstart + wid; w++) {
         drawPixel(image, x, w, color,
             alpha: ((frac >> 8) & 0xff) / 255,
+            blend: blend,
             mask: mask,
             maskChannel: maskChannel);
 
         drawPixel(image, x, w + 1, color,
             alpha: ((xor(frac) >> 8) & 0xff) / 255,
+            blend: blend,
             mask: mask,
             maskChannel: maskChannel);
       }
@@ -356,6 +374,7 @@ Image _drawLineWu(Image image,
     required int x2,
     required int y2,
     required Color color,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   final bool steep = (y2 - y1).abs() > (x2 - x1).abs();
@@ -391,21 +410,25 @@ Image _drawLineWu(Image image,
   if (steep) {
     drawPixel(image, ypxl1, xpxl1, color,
         alpha: (1 - (yend - yend.floor())) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
 
     drawPixel(image, ypxl1 + 1, xpxl1, color,
         alpha: (yend - yend.floor()) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   } else {
     drawPixel(image, xpxl1, ypxl1, color,
         alpha: (1 - (yend - yend.floor())) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
 
     drawPixel(image, xpxl1, ypxl1 + 1, color,
         alpha: (yend - yend.floor()) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -422,11 +445,13 @@ Image _drawLineWu(Image image,
   if (steep) {
     drawPixel(image, ypxl2, xpxl2, color,
         alpha: (1.0 - (yend - yend.floor())) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
 
     drawPixel(image, ypxl2 + 1, xpxl2, color,
         alpha: (yend - yend.floor()) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
 
@@ -434,22 +459,28 @@ Image _drawLineWu(Image image,
     for (var x = xpxl1 + 1; x <= xpxl2 - 1; x++) {
       drawPixel(image, intery.floor(), x, color,
           alpha: 1.0 - (intery - intery.floor()),
+          blend: blend,
           mask: mask,
           maskChannel: maskChannel);
 
       drawPixel(image, intery.floor() + 1, x, color,
-          alpha: intery - intery.floor(), mask: mask, maskChannel: maskChannel);
+          alpha: intery - intery.floor(),
+          blend: blend,
+          mask: mask,
+          maskChannel: maskChannel);
 
       intery = intery + gradient;
     }
   } else {
     drawPixel(image, xpxl2, ypxl2, color,
         alpha: (1.0 - (yend - yend.floor())) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
 
     drawPixel(image, xpxl2, ypxl2 + 1, color,
         alpha: (yend - yend.floor()) * xgap,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
 
@@ -457,11 +488,15 @@ Image _drawLineWu(Image image,
     for (var x = xpxl1 + 1; x <= xpxl2 - 1; x++) {
       drawPixel(image, x, intery.floor(), color,
           alpha: 1.0 - (intery - intery.floor()),
+          blend: blend,
           mask: mask,
           maskChannel: maskChannel);
 
       drawPixel(image, x, intery.floor() + 1, color,
-          alpha: intery - intery.floor(), mask: mask, maskChannel: maskChannel);
+          alpha: intery - intery.floor(),
+          blend: blend,
+          mask: mask,
+          maskChannel: maskChannel);
 
       intery = intery + gradient;
     }

--- a/lib/src/draw/draw_line.dart
+++ b/lib/src/draw/draw_line.dart
@@ -1,6 +1,12 @@
 import 'dart:math';
 
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../image/image.dart';
+import '../util/clip_line.dart';
+import 'blend_mode.dart';
+import 'draw_pixel.dart';
+import 'fill_circle.dart';
 
 /// Draw a line into [image].
 ///

--- a/lib/src/draw/draw_polygon.dart
+++ b/lib/src/draw/draw_polygon.dart
@@ -1,4 +1,10 @@
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../draw/draw_line.dart';
+import '../draw/draw_pixel.dart';
+import '../image/image.dart';
+import '../util/point.dart';
+import 'blend_mode.dart';
 
 /// Fill a polygon defined by the given [vertices].
 Image drawPolygon(Image src,

--- a/lib/src/draw/draw_polygon.dart
+++ b/lib/src/draw/draw_polygon.dart
@@ -1,9 +1,4 @@
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../draw/draw_line.dart';
-import '../draw/draw_pixel.dart';
-import '../image/image.dart';
-import '../util/point.dart';
+import '../../image.dart';
 
 /// Fill a polygon defined by the given [vertices].
 Image drawPolygon(Image src,
@@ -11,6 +6,7 @@ Image drawPolygon(Image src,
     required Color color,
     bool antialias = false,
     num thickness = 1,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   if (color.a == 0) {
@@ -25,7 +21,7 @@ Image drawPolygon(Image src,
 
   if (numVertices == 1) {
     return drawPixel(src, vertices[0].xi, vertices[0].yi, color,
-        mask: mask, maskChannel: maskChannel);
+        blend: blend, mask: mask, maskChannel: maskChannel);
   }
 
   if (numVertices == 2) {
@@ -37,6 +33,7 @@ Image drawPolygon(Image src,
         color: color,
         antialias: antialias,
         thickness: thickness,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -50,6 +47,7 @@ Image drawPolygon(Image src,
         color: color,
         antialias: antialias,
         thickness: thickness,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -62,6 +60,7 @@ Image drawPolygon(Image src,
       color: color,
       antialias: antialias,
       thickness: thickness,
+      blend: blend,
       mask: mask,
       maskChannel: maskChannel);
 

--- a/lib/src/draw/draw_polygon.dart
+++ b/lib/src/draw/draw_polygon.dart
@@ -9,7 +9,7 @@ Image drawPolygon(Image src,
     BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
-  if (color.a == 0) {
+  if (blend == BlendMode.alpha && color.a == 0) {
     return src;
   }
 

--- a/lib/src/draw/draw_rect.dart
+++ b/lib/src/draw/draw_rect.dart
@@ -1,10 +1,7 @@
 import 'dart:math';
 
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../image/image.dart';
+import '../../image.dart';
 import '_draw_antialias_circle.dart';
-import 'draw_line.dart';
 
 /// Draw a rectangle in the image [dst] with the [color].
 Image drawRect(Image dst,
@@ -15,6 +12,7 @@ Image drawRect(Image dst,
     required Color color,
     num thickness = 1,
     num radius = 0,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   final x0 = min(x1, x2);
@@ -25,10 +23,21 @@ Image drawRect(Image dst,
   // Draw a rounded rectangle
   if (radius > 0) {
     final rad = radius.round();
-    drawLine(dst, x1: x0 + rad, y1: y0, x2: x1 - rad, y2: y0, color: color);
-    drawLine(dst, x1: x1, y1: y0 + rad, x2: x1, y2: y1 - rad, color: color);
-    drawLine(dst, x1: x0 + rad, y1: y1, x2: x1 - rad, y2: y1, color: color);
-    drawLine(dst, x1: x0, y1: y0 + rad, x2: x0, y2: y1 - rad, color: color);
+    drawLine(
+      dst,
+      x1: x0 + rad,
+      y1: y0,
+      x2: x1 - rad,
+      y2: y0,
+      color: color,
+      blend: blend,
+    );
+    drawLine(dst,
+        x1: x1, y1: y0 + rad, x2: x1, y2: y1 - rad, color: color, blend: blend);
+    drawLine(dst,
+        x1: x0 + rad, y1: y1, x2: x1 - rad, y2: y1, color: color, blend: blend);
+    drawLine(dst,
+        x1: x0, y1: y0 + rad, x2: x0, y2: y1 - rad, color: color, blend: blend);
 
     final c1x = x0 + rad;
     final c1y = y0 + rad;
@@ -44,6 +53,7 @@ Image drawRect(Image dst,
         y: c1y,
         radius: rad,
         color: color,
+        blend: blend,
         maskChannel: maskChannel,
         mask: mask,
         quadrants: topLeftQuadrant);
@@ -53,6 +63,7 @@ Image drawRect(Image dst,
         y: c2y,
         radius: rad,
         color: color,
+        blend: blend,
         maskChannel: maskChannel,
         mask: mask,
         quadrants: topRightQuadrant);
@@ -62,6 +73,7 @@ Image drawRect(Image dst,
         y: c3y,
         radius: rad,
         color: color,
+        blend: blend,
         maskChannel: maskChannel,
         mask: mask,
         quadrants: bottomRightQuadrant);
@@ -71,6 +83,7 @@ Image drawRect(Image dst,
         y: c4y,
         radius: rad,
         color: color,
+        blend: blend,
         maskChannel: maskChannel,
         mask: mask,
         quadrants: bottomLeftQuadrant);
@@ -87,6 +100,7 @@ Image drawRect(Image dst,
       y2: y0,
       color: color,
       thickness: thickness,
+      blend: blend,
       mask: mask,
       maskChannel: maskChannel);
 
@@ -97,6 +111,7 @@ Image drawRect(Image dst,
       y2: y1,
       color: color,
       thickness: thickness,
+      blend: blend,
       mask: mask,
       maskChannel: maskChannel);
 
@@ -115,6 +130,7 @@ Image drawRect(Image dst,
       y2: by1,
       color: color,
       thickness: thickness,
+      blend: blend,
       mask: mask,
       maskChannel: maskChannel);
 
@@ -125,6 +141,7 @@ Image drawRect(Image dst,
       y2: by1,
       color: color,
       thickness: thickness,
+      blend: blend,
       mask: mask,
       maskChannel: maskChannel);
 

--- a/lib/src/draw/draw_rect.dart
+++ b/lib/src/draw/draw_rect.dart
@@ -1,7 +1,11 @@
 import 'dart:math';
 
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../image/image.dart';
 import '_draw_antialias_circle.dart';
+import 'blend_mode.dart';
+import 'draw_line.dart';
 
 /// Draw a rectangle in the image [dst] with the [color].
 Image drawRect(Image dst,

--- a/lib/src/draw/draw_string.dart
+++ b/lib/src/draw/draw_string.dart
@@ -1,4 +1,9 @@
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../font/bitmap_font.dart';
+import '../image/image.dart';
+import 'blend_mode.dart';
+import 'draw_pixel.dart';
 
 /// Draw a string horizontally into [image] at
 /// position [x],[y] with the given [color].

--- a/lib/src/draw/draw_string.dart
+++ b/lib/src/draw/draw_string.dart
@@ -1,8 +1,4 @@
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../font/bitmap_font.dart';
-import '../image/image.dart';
-import 'draw_pixel.dart';
+import '../../image.dart';
 
 /// Draw a string horizontally into [image] at
 /// position [x],[y] with the given [color].
@@ -19,6 +15,7 @@ Image drawString(Image image, String string,
     Color? color,
     bool rightJustify = false,
     bool wrap = false,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   if (color?.a == 0) {
@@ -78,6 +75,7 @@ Image drawString(Image image, String string,
               x: sx,
               y: sy,
               color: color,
+              blend: blend,
               mask: mask,
               maskChannel: maskChannel,
               rightJustify: rightJustify);
@@ -98,6 +96,7 @@ Image drawString(Image image, String string,
               x: sx,
               y: sy,
               color: color,
+              blend: blend,
               mask: mask,
               maskChannel: maskChannel,
               rightJustify: rightJustify);
@@ -144,7 +143,10 @@ Image drawString(Image image, String string,
         for (var xi = sx; xi < x2; ++xi, cIter.moveNext()) {
           final p = cIter.current;
           drawPixel(image, xi + ch.xOffset, yi + ch.yOffset, p,
-              filter: color, mask: mask, maskChannel: maskChannel);
+              filter: color,
+              blend: blend,
+              mask: mask,
+              maskChannel: maskChannel);
         }
       }
 

--- a/lib/src/draw/draw_string.dart
+++ b/lib/src/draw/draw_string.dart
@@ -18,7 +18,7 @@ Image drawString(Image image, String string,
     BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
-  if (color?.a == 0) {
+  if (blend == BlendMode.alpha && color?.a == 0) {
     return image;
   }
 

--- a/lib/src/draw/fill_circle.dart
+++ b/lib/src/draw/fill_circle.dart
@@ -1,7 +1,11 @@
 import 'dart:math';
 
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../image/image.dart';
 import '../util/_circle_test.dart';
+import 'blend_mode.dart';
+import 'draw_pixel.dart';
 
 /// Draw and fill a circle into the [image] with a center of [x],[y]
 /// and the given [radius] and [color].

--- a/lib/src/draw/fill_circle.dart
+++ b/lib/src/draw/fill_circle.dart
@@ -1,10 +1,7 @@
 import 'dart:math';
 
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../image/image.dart';
+import '../../image.dart';
 import '../util/_circle_test.dart';
-import 'draw_pixel.dart';
 
 /// Draw and fill a circle into the [image] with a center of [x],[y]
 /// and the given [radius] and [color].
@@ -14,6 +11,7 @@ Image fillCircle(Image image,
     required int radius,
     required Color color,
     bool antialias = false,
+    BlendMode blend = BlendMode.alpha,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
   final radiusSqr = radius * radius;
@@ -30,14 +28,15 @@ Image fillCircle(Image image,
       if (a > 0) {
         final alpha = color.aNormalized * a;
         drawPixel(image, p.x, p.y, color,
-            alpha: alpha, mask: mask, maskChannel: maskChannel);
+            alpha: alpha, blend: blend, mask: mask, maskChannel: maskChannel);
       }
     } else {
       final dx = p.x - x;
       final dy = p.y - y;
       final d2 = dx * dx + dy * dy;
       if (d2 < radiusSqr) {
-        drawPixel(image, p.x, p.y, color, mask: mask, maskChannel: maskChannel);
+        drawPixel(image, p.x, p.y, color,
+            blend: blend, mask: mask, maskChannel: maskChannel);
       }
     }
   }

--- a/lib/src/draw/fill_polygon.dart
+++ b/lib/src/draw/fill_polygon.dart
@@ -9,7 +9,7 @@ Image fillPolygon(Image src,
     required Color color,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
-  if (color.a == 0) {
+  if (blend == BlendMode.alpha && color.a == 0) {
     return src;
   }
 

--- a/lib/src/draw/fill_polygon.dart
+++ b/lib/src/draw/fill_polygon.dart
@@ -1,6 +1,12 @@
 import 'dart:math';
 
-import '../../image.dart';
+import '../color/channel.dart';
+import '../color/color.dart';
+import '../draw/draw_line.dart';
+import '../draw/draw_pixel.dart';
+import '../image/image.dart';
+import '../util/point.dart';
+import 'blend_mode.dart';
 
 /// Fill a polygon defined by the given [vertices].
 Image fillPolygon(Image src,

--- a/lib/src/draw/fill_polygon.dart
+++ b/lib/src/draw/fill_polygon.dart
@@ -1,15 +1,11 @@
 import 'dart:math';
 
-import '../color/channel.dart';
-import '../color/color.dart';
-import '../draw/draw_line.dart';
-import '../draw/draw_pixel.dart';
-import '../image/image.dart';
-import '../util/point.dart';
+import '../../image.dart';
 
 /// Fill a polygon defined by the given [vertices].
 Image fillPolygon(Image src,
     {required List<Point> vertices,
+    BlendMode blend = BlendMode.alpha,
     required Color color,
     Image? mask,
     Channel maskChannel = Channel.luminance}) {
@@ -25,7 +21,7 @@ Image fillPolygon(Image src,
 
   if (numVertices == 1) {
     return drawPixel(src, vertices[0].xi, vertices[0].yi, color,
-        mask: mask, maskChannel: maskChannel);
+        blend: blend, mask: mask, maskChannel: maskChannel);
   }
 
   if (numVertices == 2) {
@@ -35,6 +31,7 @@ Image fillPolygon(Image src,
         x2: vertices[1].xi,
         y2: vertices[1].yi,
         color: color,
+        blend: blend,
         mask: mask,
         maskChannel: maskChannel);
   }
@@ -83,7 +80,8 @@ Image fillPolygon(Image src,
       }
       // Even number of intersections means inside
       if (intersections & 0x1 == 1) {
-        drawPixel(src, xi, yi, color, mask: mask, maskChannel: maskChannel);
+        drawPixel(src, xi, yi, color,
+            blend: blend, mask: mask, maskChannel: maskChannel);
       }
     }
   }

--- a/test/_test_util.dart
+++ b/test/_test_util.dart
@@ -1,12 +1,11 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:image/image.dart';
 import 'package:test/test.dart';
 
-final testOutputPath = '${Directory.systemTemp.createTempSync().path}/out';
-//const testOutputPath = './_out';
+// final testOutputPath = '${Directory.systemTemp.createTempSync().path}/out';
+const testOutputPath = './_out';
 
 int hashImage(Image image) {
   var hash = 0;

--- a/test/_test_util.dart
+++ b/test/_test_util.dart
@@ -1,11 +1,12 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:image/image.dart';
 import 'package:test/test.dart';
 
-// final testOutputPath = '${Directory.systemTemp.createTempSync().path}/out';
-const testOutputPath = './_out';
+final testOutputPath = '${Directory.systemTemp.createTempSync().path}/out';
+//const testOutputPath = './_out';
 
 int hashImage(Image image) {
   var hash = 0;

--- a/test/draw/fill_circle_test.dart
+++ b/test/draw/fill_circle_test.dart
@@ -19,5 +19,25 @@ void main() {
             ..writeToFile('$testOutputPath/draw/fillCircle.png'))
           .execute();
     });
+
+    test('fillCircleWithBlendDirect', () async {
+      await (Command()
+            ..createImage(width: 256, height: 256, numChannels: 4)
+            ..fillCircle(
+                x: 128,
+                y: 128,
+                radius: 100,
+                antialias: true,
+                color: ColorRgba8(255, 255, 0, 200))
+            ..fillCircle(
+                x: 128,
+                y: 128,
+                radius: 50,
+                // Will force setting a central area to transparent
+                color: ColorRgba8(0, 255, 0, 0),
+                blend: BlendMode.direct)
+            ..writeToFile('$testOutputPath/draw/fillCircleWithBlendDirect.png'))
+          .execute();
+    });
   });
 }


### PR DESCRIPTION
Many `draw*` commands did not include the BlendMode. This is a problem when you want to draw transparency over an area of an image that already contains some data.

This PR adds support for the BlendMode to all the draw/fill commands that are missing it (as far as I can tell). Some fill commands do NOT need it because they set the values for each pixel manually, and that's why they've been skipped.

Example of the fill in [test/draw/fill_circle_test.dart](https://github.com/brendan-duncan/image/pull/742/files#diff-374b589a79913e7a27a88faba2ee1fe9233fbed3efaf710da049d90fee4a3c2b).

Normal color overlap (existing code):

<img width="256" height="256" alt="fillCircle" src="https://github.com/user-attachments/assets/ddf83eb4-41d8-47ae-8e06-fbb02aeb9838" />

Transparency paint (without blend mode):

<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/4cd21ff5-511a-4563-9474-4e29254e772c" />

Transparency paint (WITH blend mode fix): 

<img width="256" height="256" alt="fillCircleWithBlendDirect" src="https://github.com/user-attachments/assets/10ce100f-bfdd-4f2c-b510-cfc1ce2f2d94" />
