### PR TITLE
Fix rgbToHsv value for zero delta

### DIFF
--- a/lib/src/util/color_util.dart
+++ b/lib/src/util/color_util.dart
@@ -188,7 +188,7 @@ void rgbToHsv(num r, num g, num b, List<num> hsv) {
   if (maxCh == 0 || delta == 0) {
     hsv[0] = 0;
     hsv[1] = 0;
-    hsv[2] = 0;
+    hsv[2] = maxCh;
     return;
   }
 


### PR DESCRIPTION
No existing issue found; reporting directly via PR.

## Summary
- Fix `rgbToHsv` so grayscale colors (when `delta == 0`) correctly calculate their value (V) component instead of being forced to 0.
- **Repro/Example:** `rgbToHsv(128, 128, 128, hsv)` previously yielded V=0, but now correctly returns V=128.

## Testing
- All existing tests pass via `dart test`

Thanks for maintaining this package!