### PR TITLE
Fixed bug where App1 marker would not be set

### DIFF
--- a/lib/src/formats/jpeg/jpeg_util.dart
+++ b/lib/src/formats/jpeg/jpeg_util.dart
@@ -82,6 +82,10 @@ class JpegUtil {
 
     // If the JPEG file does not have an EXIF block, add a new one.
     if (!hasExifBlock) {
+      // Write APP1 marker then the EXIF block. When there is no existing
+      // APP1 segment the marker bytes won't have been written to `output`.
+      output..writeByte(0xff)
+      ..writeByte(JpegMarker.app1);
       _writeAPP1(output, exif);
       // No need to parse the remaining individual blocks, just write out
       // the remainder of the file.


### PR DESCRIPTION
Hey brendan!

Some users of my application found a bug which I retraced to your implementation of the exif injection logic. To be more specific:
When a jpg without an exif block is supplied to the injectJpgExif() function, you attempt to write the content of the App1 marker but forgot to write the App1 marker itself which corrupts the file.

Some samples:
Input:
![Screenshot_20181117-102002](https://github.com/user-attachments/assets/58c5ef1b-2a84-4a2c-a5ca-0fe1ae01c748)
Output with your version (first bytes are FF D8 00 90):
https://private-user-images.githubusercontent.com/162986/516797106-da029ffb-87d7-4f81-88a9-f909b559b5e6.jpg?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjUzNjgyNzQsIm5iZiI6MTc2NTM2Nzk3NCwicGF0aCI6Ii8xNjI5ODYvNTE2Nzk3MTA2LWRhMDI5ZmZiLTg3ZDctNGY4MS04OGE5LWY5MDliNTU5YjVlNi5qcGc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUxMjEwJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MTIxMFQxMTU5MzRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00NzUzMzk1ODliNzNmZmVhOTllYjk3YzJhY2YzYTUzYzhhZjNlYTBjZjgwNWFkNzJiZWQ3NWU3YzI5ZGEyNTQ1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.R2T-Go3nok8C3Zj7E58NIdBd4mu8-2ZlppKA0LBPkjc
Output with my changes (first bytes are FF D8 FF E1):
![Screenshot_20181117-102002](https://github.com/user-attachments/assets/67bfc045-96b8-446d-b967-534abb257967)

Please see the discussion in an issue of my project for reference:
https://github.com/Xentraxx/GooglePhotosTakeoutHelper/issues/95