### PR TITLE
Fix webp conversion bug

### DIFF
--- a/lib/src/formats/webp_encoder.dart
+++ b/lib/src/formats/webp_encoder.dart
@@ -133,6 +133,13 @@ class WebPEncoder extends Encoder {
         for (var ci = candidates.length - 1; ci >= 0; ci--) {
           final c = candidates[ci];
           final dist = j - c;
+
+          // VP8L spec limits max distance to 1048576.
+          // The first 120 values are reserved, so the actual
+          // maximum distance is 1048576 - 120 offset = 1048456
+          // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#522_lz77_backward_reference
+          if (dist > 1048456) break;
+
           // Extend the match forward.
           var len = 1;
           while (len < maxMatchLen &&


### PR DESCRIPTION
I tried out the new webp functionality from #777 and found that image conversion tended to fail conversion with this error:

```
RangeError (length): Invalid value: Not in inclusive range 0..39: 40
```

It seems like the [Prefix code](https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#522_lz77_backward_reference) is out of range because the measured distance is too high in large-ish images. This PR caps the distance at the maximum valid value.

I tested this with the [Dash image (.png) from flutter.dev](https://flutter.dev/brand#:~:text=Dash%20is%20the%20mascot%20for%20the%20Dart%20language%20and%20the%20Flutter%20framework.), and it failed with the current implementation, but the conversion worked correctly with this fix.