### PR TITLE
Fix histogram stretch variable mistake

### DIFF
--- a/lib/src/filter/histogram_equalization.dart
+++ b/lib/src/filter/histogram_equalization.dart
@@ -192,7 +192,7 @@ Image histogramStretch(Image src,
           (l - lowPercentileBin) * outputDynamicRange / inputDynamicRange +
               outputRangeMin;
       Hmap[l] =
-          max(outputRangeMin, min(newIntensityLv.round(), outputDynamicRange));
+          max(outputRangeMin, min(newIntensityLv.round(), outputRangeMax));
     }
 
     // produce output

--- a/lib/src/filter/histogram_equalization.dart
+++ b/lib/src/filter/histogram_equalization.dart
@@ -213,12 +213,12 @@ void _applyHistogramTransform(Image frame, List<num> Hmap,
       continue;
     }
     if (mode == HistogramEqualizeMode.grayscale) {
-      final oriLuminance = p.luminance;
-      final oriLuminanceInt = oriLuminance.round();
-      final residual = oriLuminance - oriLuminanceInt;
+      final oriLuminance = p.luminance.clamp(0, maxChannelValue);
+      final baseIndex = min(oriLuminance.floor(), Hmap.length - 1);
+      final frac = oriLuminance - baseIndex;
 
-      final newl = (Hmap[oriLuminanceInt] * (1 - residual) +
-              Hmap[min(oriLuminanceInt + 1, Hmap.length - 1)] * residual)
+      final newl = (Hmap[baseIndex] * (1 - frac) +
+              Hmap[min(baseIndex + 1, Hmap.length - 1)] * frac)
           .round();
 
       final msk = mask?.getPixel(p.x, p.y).getChannelNormalized(maskChannel);
@@ -236,11 +236,11 @@ void _applyHistogramTransform(Image frame, List<num> Hmap,
     } else {
       // color mode
       final hsl = rgbToHsl(p.r, p.g, p.b);
-      final oriLuminance = hsl[2] * maxChannelValue;
-      final oriLuminanceInt = oriLuminance.round();
-      final residual = oriLuminance - oriLuminanceInt;
-      final newl = (Hmap[oriLuminanceInt] * (1 - residual) +
-              Hmap[min(oriLuminanceInt + 1, Hmap.length - 1)] * residual)
+      final oriLuminance = hsl[2].clamp(0, 1) * maxChannelValue;
+      final baseIndex = min(oriLuminance.floor(), Hmap.length - 1);
+      final frac = oriLuminance - baseIndex;
+      final newl = (Hmap[baseIndex] * (1 - frac) +
+              Hmap[min(baseIndex + 1, Hmap.length - 1)] * frac)
           .round();
 
       final List<int> newRGB = [0, 0, 0];

--- a/lib/src/filter/histogram_equalization.dart
+++ b/lib/src/filter/histogram_equalization.dart
@@ -68,6 +68,7 @@ Image histogramEqualization(Image src,
       H[l.round()]++;
       validPixelCounts++;
     }
+    if (validPixelCounts == 0) continue;
 
     final double numPixelPerBin = validPixelCounts / numOutputBin;
     final List<num> Hmap = List<num>.generate(
@@ -162,6 +163,7 @@ Image histogramStretch(Image src,
       H[l.round()]++;
       validPixelCounts++;
     }
+    if (validPixelCounts == 0) continue;
 
     // Find the high & low percentile
     int lowPercentileBin = 0;
@@ -211,7 +213,13 @@ void _applyHistogramTransform(Image frame, List<num> Hmap,
       continue;
     }
     if (mode == HistogramEqualizeMode.grayscale) {
-      final newl = Hmap[p.luminance.round()];
+      final oriLuminance = p.luminance;
+      final oriLuminanceInt = oriLuminance.round();
+      final residual = oriLuminance - oriLuminanceInt;
+
+      final newl = (Hmap[oriLuminanceInt] * (1 - residual) +
+              Hmap[min(oriLuminanceInt + 1, Hmap.length - 1)] * residual)
+          .round();
 
       final msk = mask?.getPixel(p.x, p.y).getChannelNormalized(maskChannel);
       if (msk == null) {
@@ -228,7 +236,13 @@ void _applyHistogramTransform(Image frame, List<num> Hmap,
     } else {
       // color mode
       final hsl = rgbToHsl(p.r, p.g, p.b);
-      final newl = Hmap[(hsl[2] * maxChannelValue).round()];
+      final oriLuminance = hsl[2] * maxChannelValue;
+      final oriLuminanceInt = oriLuminance.round();
+      final residual = oriLuminance - oriLuminanceInt;
+      final newl = (Hmap[oriLuminanceInt] * (1 - residual) +
+              Hmap[min(oriLuminanceInt + 1, Hmap.length - 1)] * residual)
+          .round();
+
       final List<int> newRGB = [0, 0, 0];
       hslToRgb(hsl[0], hsl[1], newl / maxChannelValue, newRGB);
 

--- a/test/filter/histogram_equalization_test.dart
+++ b/test/filter/histogram_equalization_test.dart
@@ -331,6 +331,7 @@ void main() {
       for (int l = 221; l < 256; ++l) {
         expect(H[l], equals(0));
       }
+      expect(H[220], greaterThan(0));
 
       File('$testOutputPath/filter/histogramStretch_minmax.jpg')
         ..createSync(recursive: true)


### PR DESCRIPTION
In histogramStretch function `outputRangeMax` was mistakenly written as `outputDynamicRange`, leading to incorrect calculation.

Slightly improved interpolation in histogram mapping.