### PR TITLE
Allow xml 7, upgrade dev dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,13 @@ environment:
 dependencies:
   archive: ^4.0.7
   meta: ^1.3.0
-  xml: ^6.0.1
+  xml: ">=6.0.1 <8.0.0"
 
 dev_dependencies:
   build_runner: ^2.1.5
-  build_test: ^2.1.4
+  build_test: ^3.5.15
   http: ^1.1.0
   intl: ^0.20.2
-  lints: ^5.1.1
+  lints: ^6.1.0
   test: ^1.16.0
   web: ^1.1.0


### PR DESCRIPTION
XML 7 only deprecated things, and don't remove anything.
See https://pub.dev/packages/xml/changelog

I changed the version constraints to allow xml 7, but don't replace the deprecated things to also allow xml 6.

Additionally I also upgraded the dev dependencies which had dep deps that are discontinued.