### PR TITLE
Avoid using an unused StackTrace variable

### DIFF
--- a/lib/src/formats/jpeg/jpeg_data.dart
+++ b/lib/src/formats/jpeg/jpeg_data.dart
@@ -393,7 +393,7 @@ class JpegData {
       // Comment
       try {
         comment = appData.readStringUtf8();
-      } catch (e, _) {
+      } catch (_) {
         // readString without 0x00 terminator causes exception. Technically
         // bad data, but no reason to abort the rest of the image decoding.
       }


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/55738. We don't need the StackTrace variable.