### PR TITLE
Fix PNM files being misdetected as TGA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.9.2
 
+- Fix binary PNM files being misdetected as TGA, by probing PNM before TGA in
+  `findDecoderForData`.
+
 - Fix `injectJpgExif` dropping any segment (such as the JFIF APP0 header) that
   precedes the EXIF APP1 block, and losing the embedded EXIF thumbnail.
 - Remove xml dependency, replacing it with a minimal built-in parser for the

--- a/lib/src/formats/formats.dart
+++ b/lib/src/formats/formats.dart
@@ -234,6 +234,15 @@ Decoder? findDecoderForData(List<int> data) {
     return bmp;
   }
 
+  // Probe PNM before TGA. PnmDecoder.isValidFile requires an exact P1-P6 magic
+  // token, while TGA has no magic bytes and its validation only checks the
+  // pixel depth and colormap fields, so a binary PNM header can satisfy it and
+  // the TGA reader then overruns (#744). The strictly identified format wins.
+  final pnm = PnmDecoder();
+  if (pnm.isValidFile(bytes)) {
+    return pnm;
+  }
+
   final tga = TgaDecoder();
   if (tga.isValidFile(bytes)) {
     return tga;
@@ -247,11 +256,6 @@ Decoder? findDecoderForData(List<int> data) {
   final pvr = PvrDecoder();
   if (pvr.isValidFile(bytes)) {
     return pvr;
-  }
-
-  final pnm = PnmDecoder();
-  if (pnm.isValidFile(bytes)) {
-    return pnm;
   }
 
   return null;

--- a/test/formats/pnm_detection_test.dart
+++ b/test/formats/pnm_detection_test.dart
@@ -1,0 +1,24 @@
+import 'dart:typed_data';
+
+import 'package:image/image.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('binary PNM is not misdetected as TGA (#744)', () {
+    // A 4x4 binary PGM whose bytes also satisfy TGA's loose validation: TGA has
+    // no magic bytes, byte 1 (0x35) is not a colormap type, byte 2 (0x0a) is a
+    // valid image type, and byte 16 here is 24, a valid TGA pixel depth. With
+    // TGA probed before PNM, this file was claimed by the TGA decoder.
+    final header = 'P5\n4 4\n255\n'.codeUnits; // 11 bytes
+    final pixels = List<int>.generate(16, (i) => i == 5 ? 24 : (i * 15) % 256);
+    final bytes = Uint8List.fromList([...header, ...pixels]);
+    expect(bytes[16], 24, reason: 'the byte TGA reads as pixel depth');
+
+    expect(findFormatForData(bytes), ImageFormat.pnm);
+
+    final image = decodeImage(bytes);
+    expect(image, isNotNull);
+    expect(image!.width, 4);
+    expect(image.height, 4);
+  });
+}


### PR DESCRIPTION
Closes #744.

### The problem

Decoding a binary PNM file (for example a `P5` PGM) can be misdetected as TGA,
corrupting the result or throwing a `RangeError`.

`findDecoderForData` probes TGA before PNM. TGA has no magic bytes, and its
validation only checks the pixel depth and colormap fields. A binary PNM header
often lines up: byte 2 is a newline (`0x0a`), which is a valid TGA image type,
and byte 16 frequently lands on a valid TGA pixel depth (8, 16, 24 or 32). So
TGA claims the file and its reader overruns.

### The fix

Probe PNM before TGA. `PnmDecoder.isValidFile` accepts only an exact `P1` to
`P6` magic token, so no genuine TGA or other file can be captured by the earlier
check, and the strictly identified format simply wins. It is a one-block
reorder, with no public API or output change.

### Tests

Added `test/formats/pnm_detection_test.dart`: a crafted 4x4 binary `P5`, whose
bytes satisfy TGA's loose validation (byte 16 is 24, a valid pixel depth), is
now detected as `ImageFormat.pnm` and decodes to the correct image. I checked it
both ways: before the fix `findFormatForData` returns `ImageFormat.tga` and the
test fails; after the fix it passes. Full suite green (1109 tests).
