### PR TITLE
refactor: rename dither `strength` parameter to `intensity`

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -316,7 +316,7 @@ void ditherImage({ Quantizer? quantizer,
   DitherKernel kernel = DitherKernel.floydSteinberg,
   bool serpentine = false,
   DitherScanOrder? scanOrder,
-  double strength = 1.0 });
+  double intensity = 1.0 });
 
 void dotScreen({ num angle = 180, num size = 5.75, int? centerX,
   int? centerY, num amount = 1, Command? mask,

--- a/doc/filters.md
+++ b/doc/filters.md
@@ -121,7 +121,7 @@ Image copyImageChannels(Image src, { required Image from, bool scaled = false,
 Image ditherImage(Image image, { Quantizer? quantizer,
   DitherKernel kernel = DitherKernel.floydSteinberg,
   bool serpentine = false,
-  double strength = 1.0,
+  double intensity = 1.0,
   DitherScanOrder? scanOrder })
 ```
 
@@ -160,13 +160,13 @@ replacement.
 `ditherImage` also supports ordered **Bayer** dithering via the
 `DitherKernel.bayer2x2`, `bayer4x4` and `bayer8x8` kernels. Unlike the
 error-diffusion kernels, it uses a fixed threshold matrix (so `serpentine` has
-no effect), and `strength` scales the dither amount.
+no effect), and `intensity` scales the dither amount.
 
 ![dither_Bayer8x8.png](images/filter/dither_Bayer8x8.png)
 
 ```dart
 Image ditherImageBayer(Image image, [Quantizer? quantizer,
-    DitherKernel kernel = DitherKernel.bayer4x4, double strength = 1.0])
+    DitherKernel kernel = DitherKernel.bayer4x4, double intensity = 1.0])
 ```
 
 ### [dotScreen](https://pub.dev/documentation/image/latest/image/dotScreen.html)

--- a/lib/src/command/command.dart
+++ b/lib/src/command/command.dart
@@ -820,14 +820,14 @@ class Command {
     // Use scanOrder: DitherScanOrder.serpentine instead.
     bool serpentine = false,
     DitherScanOrder? scanOrder,
-    double strength = 1.0,
+    double intensity = 1.0,
   }) {
     subCommand = DitherImageCmd(subCommand,
         quantizer: quantizer,
         kernel: kernel,
         scanOrder: scanOrder ??
             (serpentine ? DitherScanOrder.serpentine : DitherScanOrder.raster),
-        strength: strength);
+        intensity: intensity);
   }
 
   void dotScreen(

--- a/lib/src/command/filter/dither_image_cmd.dart
+++ b/lib/src/command/filter/dither_image_cmd.dart
@@ -11,7 +11,7 @@ class DitherImageCmd extends Command {
 
   final g.DitherScanOrder? scanOrder;
 
-  final double strength;
+  final double intensity;
 
   DitherImageCmd(
     Command? input, {
@@ -19,7 +19,7 @@ class DitherImageCmd extends Command {
     this.kernel = g.DitherKernel.floydSteinberg,
     this.serpentine = false,
     this.scanOrder,
-    this.strength = 1.0,
+    this.intensity = 1.0,
   }) : super(input);
 
   @override
@@ -33,7 +33,7 @@ class DitherImageCmd extends Command {
             quantizer: quantizer,
             kernel: kernel,
             scanOrder: order,
-            strength: strength)
+            intensity: intensity)
         : null;
   }
 }

--- a/lib/src/filter/dither_image.dart
+++ b/lib/src/filter/dither_image.dart
@@ -167,7 +167,7 @@ const _bayerMatrices = <DitherKernel, List<List<double>>>{
 /// the space-filling [DitherScanOrder.hilbert] curve).
 /// It has no effect on the Bayer kernels.
 ///
-/// [strength] scales the dither offset and is only used for the Bayer
+/// [intensity] scales the dither offset and is only used for the Bayer
 /// kernels; it is ignored by the error-diffusion kernels.
 Image ditherImage(
   Image image, {
@@ -176,7 +176,7 @@ Image ditherImage(
   // Use scanOrder: DitherScanOrder.serpentine instead.
   bool serpentine = false,
   DitherScanOrder scanOrder = DitherScanOrder.zigzag,
-  double strength = 1.0,
+  double intensity = 1.0,
 }) {
   quantizer ??= NeuralQuantizer(image);
 
@@ -185,7 +185,7 @@ Image ditherImage(
   }
 
   if (_bayerMatrices.containsKey(kernel)) {
-    return ditherImageBayer(image, quantizer, kernel, strength);
+    return ditherImageBayer(image, quantizer, kernel, intensity);
   }
 
   final order = serpentine
@@ -322,13 +322,13 @@ Image ditherImage(
 /// [quantizer] is the color reducer used to map each pixel to the palette;
 /// if `null` (the default) a [NeuralQuantizer] is built from [image].
 ///
-/// [strength] scales the dither offset (defaults to 1.0 for the classic
+/// [intensity] scales the dither offset (defaults to 1.0 for the classic
 /// full-range Bayer look; smaller values give subtler banding reduction).
 Image ditherImageBayer(
   Image image, [
   Quantizer? quantizer,
   DitherKernel kernel = DitherKernel.bayer4x4,
-  double strength = 1.0,
+  double intensity = 1.0,
 ]) {
   quantizer ??= NeuralQuantizer(image);
 
@@ -355,7 +355,7 @@ Image ditherImageBayer(
       final pc = image.getPixel(x, y);
       // Centered threshold in the range [-0.5, 0.5).
       final t = row[x % n] - 0.5;
-      final d = t * 255 * strength;
+      final d = t * 255 * intensity;
       final r = _clampChannel(pc[0] + d);
       final g = _clampChannel(pc[1] + d);
       final b = _clampChannel(pc[2] + d);

--- a/lib/src/filter/quantize.dart
+++ b/lib/src/filter/quantize.dart
@@ -16,7 +16,7 @@ Image quantize(
   // Use ditherScanOrder: DitherScanOrder.serpentine instead.
   bool ditherSerpentine = false,
   DitherScanOrder? ditherScanOrder,
-  double ditherStrength = 1.0,
+  double ditherIntensity = 1.0,
 }) {
   Quantizer quantizer;
 
@@ -36,6 +36,6 @@ Image quantize(
     quantizer: quantizer,
     kernel: dither,
     scanOrder: order,
-    strength: ditherStrength,
+    intensity: ditherIntensity,
   );
 }

--- a/lib/src/formats/gif_encoder.dart
+++ b/lib/src/formats/gif_encoder.dart
@@ -27,7 +27,7 @@ class GifEncoder extends Encoder {
 
   /// Scales the dither offset for the Bayer kernels; ignored by the
   /// error-diffusion kernels.
-  double ditherStrength;
+  double ditherIntensity;
 
   /// The disposal method applied to each frame: 0 = no action,
   /// 1 = do not dispose, 2 = restore to background, 3 = restore to previous.
@@ -42,7 +42,7 @@ class GifEncoder extends Encoder {
     this.dither = DitherKernel.floydSteinberg,
     this.ditherSerpentine = false,
     this.ditherScanOrder,
-    this.ditherStrength = 1.0,
+    this.ditherIntensity = 1.0,
     this.dispose = 2,
   }) : _encodedFrames = 0;
 
@@ -71,7 +71,7 @@ class GifEncoder extends Encoder {
             quantizer: _lastColorMap!,
             kernel: dither,
             scanOrder: _scanOrder,
-            strength: ditherStrength);
+            intensity: ditherIntensity);
       } else {
         _lastImage = image;
       }


### PR DESCRIPTION
Rename the `strength` parameter to `intensity` in `ditherImage`, `ditherImageBayer`, `quantize`, `GifEncoder`, `DitherImageCmd`, and the `Command` builder to clarify its effect as a scaling factor for dither offset rather than a generic strength value.